### PR TITLE
fix/unify Safe & Trusted Mode rendering parity

### DIFF
--- a/packages/webview-client/src/app/App.tsx
+++ b/packages/webview-client/src/app/App.tsx
@@ -68,7 +68,8 @@ function App() {
     `Render state: isLoading=${isLoading}, content=${content?.mode ?? 'null'}, error=${error ? 'yes' : 'no'}, isStale=${isStale}`
   );
 
-  // intercept Ctrl/Cmd+clicks on external links & route to extension
+  // intercept external link clicks & route to extension
+  // (webview sandbox prevents direct navigation, so all external links go through openExternal)
   const handleLinkClick = useCallback((event: MouseEvent<HTMLDivElement>) => {
     const target = event.target as HTMLElement;
     const anchor = target.closest('a');
@@ -83,15 +84,10 @@ function App() {
 
     const linkType = classifyLink(href);
 
-    // only handle external links w/ Ctrl/Cmd+click
+    // route all external links through extension
     if (linkType === 'external') {
-      const isModifierClick = event.metaKey || event.ctrlKey;
-      if (!isModifierClick) {
-        return;
-      }
-
       event.preventDefault();
-      log.debug(`Ctrl/Cmd+click external link: ${href}`);
+      log.debug(`Opening external link: ${href}`);
       ExtensionHandle.openExternal(href);
     }
   }, []);

--- a/packages/webview-client/src/features/preview/safe/SafePreview.tsx
+++ b/packages/webview-client/src/features/preview/safe/SafePreview.tsx
@@ -6,6 +6,7 @@ import { usePreviewSetup } from '../shared/hooks/usePreviewSetup';
 import { useSourceLineHighlight } from '../shared/hooks/useSourceLineHighlight';
 import { useSafeModeProcessing } from './hooks/useSafeModeProcessing';
 import { useKatexDetection } from '../../code-block/hooks/useKatexDetection';
+import { useCodeBlockEnhancement } from '../../code-block/hooks/useCodeBlockEnhancement';
 import { PreviewContainer } from '../shared/ui/PreviewContainer/PreviewContainer';
 import { fastStringEquals } from '../../../shared/utils/memoCompare';
 import { useToc } from '../../../app/state';
@@ -22,11 +23,15 @@ export const SafePreviewRenderer = memo(
 
     // shared preview setup (container ref, diagram rendering, image lightbox)
     const { containerRef, handleImageClick, renderPortals } = usePreviewSetup({
-      diagramMode: 'after-paint',
+      diagramMode: 'before-paint',
+      filterStale: true,
     });
 
-    // process Safe Mode HTML (sanitize, post-process links/images, enhance code blocks)
+    // sanitize & inject Safe Mode HTML
     useSafeModeProcessing(containerRef, html);
+
+    // enhance Shiki code blocks w/ copy buttons & language badges
+    useCodeBlockEnhancement({ containerRef, trigger: html });
 
     // bind MPE-style source-line hover highlights after HTML injection
     useSourceLineHighlight({

--- a/packages/webview-client/src/features/preview/safe/hooks/useSafeModeProcessing.ts
+++ b/packages/webview-client/src/features/preview/safe/hooks/useSafeModeProcessing.ts
@@ -1,51 +1,22 @@
 // packages/webview-client/src/features/preview/safe/hooks/useSafeModeProcessing.ts
-// encapsulates Safe Mode HTML post-processing (sanitization, link/image processing, code block enhancement)
+// encapsulates Safe Mode HTML sanitization & DOM injection
 
-import { useEffect, type RefObject } from 'react';
+import { useLayoutEffect, type RefObject } from 'react';
 import DOMPurify from 'dompurify';
-import { enhanceCodeBlocks } from '../../../code-block/ui/CodeBlock';
 import { DOMPURIFY_CONFIG, ensureSafeModeStyles } from '../security';
 
-// process links in a DocumentFragment or HTMLElement for security
-// internal anchor links (#...) are left unchanged
-// external links get target="_blank" & rel="noopener noreferrer"
-function processLinksInFragment(
-  container: DocumentFragment | HTMLElement
-): void {
-  const links = container.querySelectorAll('a');
-  links.forEach((link) => {
-    const href = link.getAttribute('href');
-    if (!href || href.startsWith('#')) {
-      return;
-    }
-    // external links (open in new tab securely)
-    link.setAttribute('target', '_blank');
-    link.setAttribute('rel', 'noopener noreferrer');
-  });
-}
-
-// add clickable cursor to images for lightbox functionality
-function processImagesInFragment(
-  container: DocumentFragment | HTMLElement
-): void {
-  const images = container.querySelectorAll('img');
-  images.forEach((img) => {
-    (img as HTMLElement).style.cursor = 'zoom-in';
-  });
-}
-
 // hook for processing Safe Mode HTML content
-// handle sanitization, security post-processing, & code block enhancement
-// this is necessarily imperative because Safe Mode renders pre-compiled HTML
-// (not React components), requiring DOM manipulation after innerHTML injection
+// handle sanitization & inject into container
+// use useLayoutEffect for synchronous DOM injection before paint
+// (prevents flash of empty/unstyled content)
 //
 // performance optimization: use DocumentFragment for off-DOM manipulation
-// to reduce layout recalculations from 4+ to 1
+// to reduce layout recalculations
 export function useSafeModeProcessing(
   containerRef: RefObject<HTMLDivElement>,
   html: string
 ): void {
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!containerRef.current) {
       return;
     }
@@ -59,20 +30,11 @@ export function useSafeModeProcessing(
     template.innerHTML = sanitizedHTML as string;
     const fragment = template.content;
 
-    // 3. process in fragment (no layout triggered - elements not in DOM)
-    // querySelectorAll works on DocumentFragment
-    processLinksInFragment(fragment);
-    processImagesInFragment(fragment);
-
-    // 4. single DOM update - only one layout recalculation
+    // 3. single DOM update - only one layout recalculation
     containerRef.current.innerHTML = '';
     containerRef.current.appendChild(fragment);
 
-    // 5. style injection (no layout, just CSS)
+    // 4. style injection (no layout, just CSS)
     ensureSafeModeStyles();
-
-    // 6. code block enhancement requires real DOM for event listeners
-    // (copy button click handlers need elements to be in the document)
-    enhanceCodeBlocks(containerRef.current);
   }, [html, containerRef]);
 }

--- a/packages/webview-client/src/features/preview/trusted/TrustedPreview.tsx
+++ b/packages/webview-client/src/features/preview/trusted/TrustedPreview.tsx
@@ -168,6 +168,7 @@ export const TrustedPreviewRenderer = memo(function TrustedPreviewRenderer({
       mode="trusted"
       onImageClick={handleImageClick}
       diagramPortals={renderPortals()}
+      className="markdown-body"
     >
       {mdxNode}
     </PreviewContainer>

--- a/tests/webview/safe-mode-processing.test.ts
+++ b/tests/webview/safe-mode-processing.test.ts
@@ -1,22 +1,11 @@
 // tests/webview/safe-mode-processing.test.ts
-// unit tests for safe-mode HTML post-processing hook behavior
+// unit tests for safe-mode HTML sanitization & DOM injection
 //
 // @vitest-environment jsdom
 
 import { act, createElement, useRef, type JSX, type RefObject } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
-const { mockEnhanceCodeBlocks } = vi.hoisted(() => ({
-  mockEnhanceCodeBlocks: vi.fn(),
-}));
-
-vi.mock(
-  '../../packages/webview-client/src/features/code-block/ui/CodeBlock',
-  () => ({
-    enhanceCodeBlocks: (...args: unknown[]) => mockEnhanceCodeBlocks(...args),
-  })
-);
 
 import { useSafeModeProcessing } from '../../packages/webview-client/src/features/preview/safe/hooks/useSafeModeProcessing';
 
@@ -86,38 +75,13 @@ describe('useSafeModeProcessing', () => {
       .forEach((node) => node.remove());
   });
 
-  it('adds target and rel for external links', async () => {
+  it('injects sanitized HTML into container', async () => {
     const { host, rerender, unmount } = createMount();
 
-    await rerender('<a href="https://example.com/docs">External</a>');
+    await rerender('<h1>Hello</h1><p>World</p>');
 
-    const external = host.querySelector('a');
-
-    expect(external?.getAttribute('target')).toBe('_blank');
-    expect(external?.getAttribute('rel')).toBe('noopener noreferrer');
-    await unmount();
-  });
-
-  it('leaves hash links unchanged', async () => {
-    const { host, rerender, unmount } = createMount();
-
-    await rerender('<a href="#section">Internal</a>');
-
-    const internal = host.querySelector('a');
-    expect(internal?.getAttribute('target')).toBeNull();
-    expect(internal?.getAttribute('rel')).toBeNull();
-
-    await unmount();
-  });
-
-  it('adds zoom-in cursor styling to images', async () => {
-    const { host, rerender, unmount } = createMount();
-
-    await rerender('<img src="/cat.png" alt="cat" />');
-
-    const image = host.querySelector('img');
-    expect(image).toBeTruthy();
-    expect((image as HTMLImageElement).style.cursor).toBe('zoom-in');
+    expect(host.querySelector('h1')?.textContent).toBe('Hello');
+    expect(host.querySelector('p')?.textContent).toBe('World');
 
     await unmount();
   });
@@ -137,4 +101,20 @@ describe('useSafeModeProcessing', () => {
     await unmount();
   });
 
+  it('preserves safe HTML elements & attributes', async () => {
+    const { host, rerender, unmount } = createMount();
+
+    await rerender(
+      '<a href="https://example.com">Link</a><img src="/cat.png" alt="cat" />'
+    );
+
+    const link = host.querySelector('a');
+    expect(link?.getAttribute('href')).toBe('https://example.com');
+
+    const img = host.querySelector('img');
+    expect(img?.getAttribute('src')).toBe('/cat.png');
+    expect(img?.getAttribute('alt')).toBe('cat');
+
+    await unmount();
+  });
 });


### PR DESCRIPTION
Safe Mode diverged from Trusted Mode in several ways beyond the fundamental HTML-vs-React difference. This aligns them:

- Add markdown-body class to TrustedPreview (restores all typography)
- Extract code block enhancement from useSafeModeProcessing into SafePreview via shared useCodeBlockEnhancement hook
- Remove redundant image cursor inline style (CSS rule already covers)
- Remove per-mode link processing; route all external link clicks through ExtensionHandle.openExternal() in App.tsx for both modes
- Switch Safe Mode to useLayoutEffect & before-paint diagram scanning to match Trusted Mode (eliminates content flash)
- Simplify useSafeModeProcessing to sanitization & DOM injection only
- Update tests to match simplified hook responsibilities