### PR TITLE
fix/vsce packaging: update lodash-es override & skip dep check

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -562,18 +562,6 @@ If you discover a security vulnerability:
 
 MDX Preview maintains awareness of dependency vulnerabilities via `npm audit`. The following moderate vulnerabilities are accepted risks:
 
-### lodash-es Prototype Pollution (GHSA-xxjr-mmjv-4gpg)
-
-**Path:** `mermaid -> @mermaid-js/parser -> langium -> chevrotain -> lodash-es`
-
-**Assessment:** Low risk
-- lodash-es is an internal dependency of Mermaid's parser
-- Not exposed to user-controlled code paths
-- Mermaid processes only trusted internal diagram definitions
-- No user input flows through the affected `_.unset` or `_.omit` functions
-
-**Mitigation:** Monitoring upstream for patches. Will update when chevrotain/langium releases fix.
-
 ### esbuild Request Forgery (GHSA-67mh-4wv8-2f99)
 
 **Path:** `vitest -> vite -> esbuild`

--- a/package.json
+++ b/package.json
@@ -685,7 +685,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run build:extension:prod && npm run build:webview-client",
-    "vscode:package": "npm run test:all && vsce package",
+    "vscode:package": "npm run test:all && vsce package --no-dependencies",
     "generate:preload": "tsx packages/codegen/src/cli/generate-preload.ts",
     "generate:schema": "tsx packages/codegen/src/cli/generate-schema.ts",
     "generate:settings": "tsx packages/codegen/src/cli/generate-settings.ts",
@@ -789,7 +789,7 @@
   "overrides": {
     "@types/node": "^20.0.0",
     "comlink": "^4.4.1",
-    "lodash-es": "4.17.21"
+    "lodash-es": "4.17.23"
   },
   "sideEffects": false,
   "directories": {


### PR DESCRIPTION
Update lodash-es override from 4.17.21 to 4.17.23 to match the actual resolved version (includes prototype pollution fix). Add --no-dependencies to vsce package since all deps are bundled via esbuild & node_modules is excluded from the VSIX. Remove resolved lodash-es vulnerability entry from security docs.