### PR TITLE
feat: configurable icon packs for mermaid architecture diagrams

### DIFF
--- a/examples/aws-architecture/.vscode/settings.json
+++ b/examples/aws-architecture/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "mdx-preview.diagrams.mermaidIconPacks": [
+    { "name": "custom", "source": "./icons/sample-pack.json" }
+  ]
+}

--- a/examples/aws-architecture/README.mdx
+++ b/examples/aws-architecture/README.mdx
@@ -1,0 +1,47 @@
+# Mermaid Architecture Diagrams with Icon Packs
+
+Mermaid [architecture diagrams](https://mermaid.js.org/syntax/architecture.html)
+can render icons from icon packs. Icons are referenced as `pack:icon-name`
+inside a service definition.
+
+## Built-in `logos` pack (AWS service logos)
+
+The `logos` pack is bundled, so `logos:aws-*` icons work with no setup:
+
+```mermaid
+architecture-beta
+    group api(logos:aws)[AWS]
+
+    service client(logos:aws-api-gateway)[API Gateway] in api
+    service fn(logos:aws-lambda)[Lambda] in api
+    service db(logos:aws-dynamodb)[DynamoDB] in api
+    service bucket(logos:aws-s3)[S3] in api
+
+    client:R --> L:fn
+    fn:R --> L:db
+    fn:B --> T:bucket
+```
+
+## Adding your own packs (no rebuild)
+
+Register extra [Iconify](https://iconify.design) packs via the
+`mdx-preview.diagrams.mermaidIconPacks` setting. This folder ships an example
+in `.vscode/settings.json` that registers `icons/sample-pack.json` under the
+name `custom`, used here:
+
+```mermaid
+architecture-beta
+    service a(custom:box)[Custom Icon]
+```
+
+To use a different pack, drop its Iconify JSON anywhere in the workspace, point
+a `{ "name": ..., "source": ... }` entry at it, and reload the preview. For the
+full AWS Architecture icon set, bundle a pack such as
+[`harmalh/aws-mermaid-icons`](https://github.com/harmalh/aws-mermaid-icons).
+
+## Notes
+
+- Packs are read by the extension host and sent to the webview, so they work
+  offline and within the webview's Content-Security-Policy (no CDN fetch).
+- Relative `source` paths resolve against the workspace folder.
+- Regular Mermaid diagrams (flowcharts, sequence diagrams, etc.) are unaffected.

--- a/examples/aws-architecture/README.mdx
+++ b/examples/aws-architecture/README.mdx
@@ -35,13 +35,18 @@ architecture-beta
 ```
 
 To use a different pack, drop its Iconify JSON anywhere in the workspace, point
-a `{ "name": ..., "source": ... }` entry at it, and reload the preview. For the
-full AWS Architecture icon set, bundle a pack such as
-[`harmalh/aws-mermaid-icons`](https://github.com/harmalh/aws-mermaid-icons).
+a `{ "name": ..., "source": ... }` entry at it, and reload the preview. Use only
+icon JSON from sources you trust — see the security note below.
 
 ## Notes
 
 - Packs are read by the extension host and sent to the webview, so they work
   offline and within the webview's Content-Security-Policy (no CDN fetch).
 - Relative `source` paths resolve against the workspace folder.
+- **Trusted workspaces only.** Icon packs are read from disk only when the
+  workspace is trusted; in Restricted Mode they're ignored. A pack's `body` is
+  SVG that gets injected into the diagram, so treat an icon pack like code: only
+  add packs from sources you'd be comfortable running. Pack contents are
+  validated and sanitized (size/shape limits, no external-resource markup), but
+  the safest posture is still trusted input.
 - Regular Mermaid diagrams (flowcharts, sequence diagrams, etc.) are unaffected.

--- a/examples/aws-architecture/icons/sample-pack.json
+++ b/examples/aws-architecture/icons/sample-pack.json
@@ -1,0 +1,10 @@
+{
+  "prefix": "custom",
+  "width": 24,
+  "height": 24,
+  "icons": {
+    "box": {
+      "body": "<path fill=\"currentColor\" d=\"M3 3h18v18H3z\" opacity=\"0.15\"/><path fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" d=\"M4 4h16v16H4zM4 9h16M9 9v11\"/>"
+    }
+  }
+}

--- a/examples/aws-architecture/package.json
+++ b/examples/aws-architecture/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "mdx-preview-aws-architecture-example",
+  "description": "MDX Preview example demonstrating Mermaid architecture diagrams with AWS icons",
+  "private": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2780,6 +2780,15 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@iconify-json/logos": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@iconify-json/logos/-/logos-1.2.11.tgz",
+      "integrity": "sha512-fOo4pGEatuyuCFNL+cwquYMa2Im0oJHRHV7lt/Qqs5Ode/lPImHCQcfTtPzZj7qYMPb/h8YHN3TG54uEowrjNQ==",
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
     "node_modules/@iconify/types": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
@@ -3126,9 +3135,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3150,9 +3156,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3174,9 +3177,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3198,9 +3198,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3222,9 +3219,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3246,9 +3240,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3426,9 +3417,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3446,9 +3434,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3466,9 +3451,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3486,9 +3468,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3506,9 +3485,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3526,9 +3502,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4034,9 +4007,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4052,9 +4022,6 @@
       "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4072,9 +4039,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4090,9 +4054,6 @@
       "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9809,9 +9770,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9831,9 +9789,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -9855,9 +9810,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9877,9 +9829,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -15248,6 +15197,7 @@
       "name": "webview",
       "version": "1.0.0",
       "dependencies": {
+        "@iconify-json/logos": "^1.2.0",
         "@mdx-js/react": "^3.0.0",
         "@mdx-preview/contracts": "*",
         "@mdx-preview/runtime-utils": "*",

--- a/package.json
+++ b/package.json
@@ -582,6 +582,29 @@
           "markdownDescription": "PlantUML rendering server URL. Supports Kroki (`https://kroki.io`) and compatible PlantUML servers.",
           "scope": "resource"
         },
+        "mdx-preview.diagrams.mermaidIconPacks": {
+          "type": "array",
+          "default": [],
+          "markdownDescription": "Icon packs for Mermaid `architecture-beta` diagrams. Each entry registers an [Iconify](https://iconify.design) JSON pack from a local file, referenced in diagrams as `name:icon` (e.g. `aws:Lambda`). The `logos` pack (AWS service logos) is built in.",
+          "scope": "resource",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "source"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "markdownDescription": "Pack name used as the icon prefix in diagrams (e.g. `aws` → `aws:Lambda`)."
+              },
+              "source": {
+                "type": "string",
+                "markdownDescription": "Path to an Iconify JSON file. Relative paths resolve against the workspace folder."
+              }
+            }
+          }
+        },
         "mdx-preview.framework": {
           "type": "string",
           "enum": [

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
       "supported": "limited",
       "description": "In Restricted Mode, MDX Preview renders content as static HTML only. JavaScript execution and custom components require a trusted workspace with scripts enabled.",
       "restrictedConfigurations": [
-        "mdx-preview.preview.enableScripts"
+        "mdx-preview.preview.enableScripts",
+        "mdx-preview.diagrams.mermaidIconPacks"
       ]
     }
   },

--- a/packages/codegen/src/cli/verify-settings.ts
+++ b/packages/codegen/src/cli/verify-settings.ts
@@ -125,7 +125,9 @@ function verifyDefault(
     return;
   }
 
-  if (packageDefault !== canonicalDefault) {
+  // compare by value so array/object defaults (e.g. []) aren't flagged as
+  // mismatched on reference inequality
+  if (JSON.stringify(packageDefault) !== JSON.stringify(canonicalDefault)) {
     errors.push(
       `Default mismatch for ${settingKey}:\n` +
         `  package.json: ${JSON.stringify(packageDefault)}\n` +

--- a/packages/contracts/src/config/defaults.ts
+++ b/packages/contracts/src/config/defaults.ts
@@ -6,6 +6,7 @@ import {
   STANDARD_WATCHER_DEBOUNCE_MS,
 } from '../runtime/constants';
 import { DEFAULT_PLANTUML_SERVER } from '../diagrams/constants';
+import type { MermaidIconPackSetting } from '../themes/types';
 
 // preview defaults
 export const DEFAULT_PREVIEW_UPDATE_MODE = 'onType' as const;
@@ -26,6 +27,7 @@ export const DEFAULT_SOURCE_LINE_HIGHLIGHT_COLOR = 'dependent' as const;
 export const DEFAULT_PREVIEW_SCROLL_SYNC = 'off' as const;
 export const DEFAULT_SHIM_SIDE_RAIL = true;
 export const DEFAULT_DIAGRAMS_PLANTUML_SERVER = DEFAULT_PLANTUML_SERVER;
+export const DEFAULT_DIAGRAMS_MERMAID_ICON_PACKS: MermaidIconPackSetting[] = [];
 
 // build defaults
 export const DEFAULT_USE_SUCRASE_TRANSPILER = false;
@@ -70,6 +72,7 @@ export const SETTINGS_DEFAULTS = {
   'preview.scrollSync': DEFAULT_PREVIEW_SCROLL_SYNC,
   'preview.shimSideRail': DEFAULT_SHIM_SIDE_RAIL,
   'diagrams.plantUmlServer': DEFAULT_DIAGRAMS_PLANTUML_SERVER,
+  'diagrams.mermaidIconPacks': DEFAULT_DIAGRAMS_MERMAID_ICON_PACKS,
   'build.useSucraseTranspiler': DEFAULT_USE_SUCRASE_TRANSPILER,
   'tailwind.enabled': DEFAULT_TAILWIND_ENABLED,
   'tailwind.maxFileSizeBytes': DEFAULT_TAILWIND_MAX_FILE_SIZE_BYTES,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -77,6 +77,8 @@ export {
   type WebviewThemeState,
   type MermaidIconPackSetting,
   type ResolvedMermaidIconPack,
+  type IconifyIcon,
+  type IconifyIconPack,
   MERMAID_THEMES,
   isLightPreviewTheme,
   PREVIEW_THEMES,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -75,6 +75,8 @@ export {
   type MermaidTheme,
   type CodeBlockTheme,
   type WebviewThemeState,
+  type MermaidIconPackSetting,
+  type ResolvedMermaidIconPack,
   MERMAID_THEMES,
   isLightPreviewTheme,
   PREVIEW_THEMES,

--- a/packages/contracts/src/themes/index.ts
+++ b/packages/contracts/src/themes/index.ts
@@ -8,6 +8,8 @@ export type {
   WebviewThemeState,
   MermaidIconPackSetting,
   ResolvedMermaidIconPack,
+  IconifyIcon,
+  IconifyIconPack,
 } from './types';
 
 export {

--- a/packages/contracts/src/themes/index.ts
+++ b/packages/contracts/src/themes/index.ts
@@ -6,6 +6,8 @@ export type {
   MermaidTheme,
   CodeBlockTheme,
   WebviewThemeState,
+  MermaidIconPackSetting,
+  ResolvedMermaidIconPack,
 } from './types';
 
 export {

--- a/packages/contracts/src/themes/types.ts
+++ b/packages/contracts/src/themes/types.ts
@@ -63,11 +63,32 @@ export interface MermaidIconPackSetting {
   source: string;
 }
 
-// mermaid icon pack after the host has read & parsed its JSON
+// a single Iconify icon: an SVG body fragment + optional geometry/transform
+export interface IconifyIcon {
+  body: string;
+  width?: number;
+  height?: number;
+  left?: number;
+  top?: number;
+  rotate?: number;
+  hFlip?: boolean;
+  vFlip?: boolean;
+}
+
+// minimal Iconify pack shape; validated & narrowed host-side before crossing
+// the RPC boundary to the webview (see IconPackResolver.validateIconifyPack)
+export interface IconifyIconPack {
+  prefix?: string;
+  width?: number;
+  height?: number;
+  icons: Record<string, IconifyIcon>;
+}
+
+// mermaid icon pack after the host has read, parsed & validated its JSON
 // ready to send to the webview for registerIconPacks
 export interface ResolvedMermaidIconPack {
   name: string;
-  icons: unknown;
+  icons: IconifyIconPack;
 }
 
 // theme state sent from extension to webview

--- a/packages/contracts/src/themes/types.ts
+++ b/packages/contracts/src/themes/types.ts
@@ -56,6 +56,20 @@ export type CodeBlockTheme =
   | 'vue'
   | 'xonokai';
 
+// mermaid icon pack as configured in settings
+// source is a workspace-relative or absolute path to an Iconify JSON file
+export interface MermaidIconPackSetting {
+  name: string;
+  source: string;
+}
+
+// mermaid icon pack after the host has read & parsed its JSON
+// ready to send to the webview for registerIconPacks
+export interface ResolvedMermaidIconPack {
+  name: string;
+  icons: unknown;
+}
+
 // theme state sent from extension to webview
 export interface WebviewThemeState {
   previewTheme: PreviewTheme;
@@ -63,4 +77,5 @@ export interface WebviewThemeState {
   mermaidTheme: MermaidTheme;
   isLight: boolean;
   plantUmlServer: string;
+  mermaidIconPacks: ResolvedMermaidIconPack[];
 }

--- a/packages/extension-host/src/features/preview/PreviewWebviewBridge.ts
+++ b/packages/extension-host/src/features/preview/PreviewWebviewBridge.ts
@@ -110,7 +110,14 @@ export class PreviewWebviewBridge {
     if (!this.webviewHandle) {
       return;
     }
-    log.debug('pushThemeState - pushing theme state', finalState);
+    // redact pack payloads (may contain file-derived content) from logs
+    log.debug('pushThemeState - pushing theme state', {
+      ...finalState,
+      mermaidIconPacks: finalState.mermaidIconPacks.map((pack) => ({
+        name: pack.name,
+        iconCount: Object.keys(pack.icons.icons).length,
+      })),
+    });
     this.webviewHandle.setTheme(finalState);
   }
 

--- a/packages/extension-host/src/features/preview/PreviewWebviewBridge.ts
+++ b/packages/extension-host/src/features/preview/PreviewWebviewBridge.ts
@@ -8,9 +8,14 @@ import { LogTags } from '@mdx-preview/contracts';
 // module-level tagged logger
 const log = createTaggedLogger(LogTags.PREVIEW);
 import { getThemeManager } from '../../app/services';
+import { resolveMermaidIconPacks } from '../themes/IconPackResolver';
 import { DocumentTracker, CustomCssWatcher, WatcherManager } from './watchers';
 import type { WebviewHandleType } from '../../platform/rpc/extension-endpoint';
 import type { PreviewRuntimeConfig } from '../types';
+import type {
+  MermaidIconPackSetting,
+  WebviewThemeState,
+} from '@mdx-preview/contracts';
 
 export type WebviewHandle = WebviewHandleType;
 
@@ -84,8 +89,29 @@ export class PreviewWebviewBridge {
       }
     }
 
-    log.debug('pushThemeState - pushing theme state', themeState);
-    this.webviewHandle.setTheme(themeState);
+    // resolve configured mermaid icon packs (async file reads) then push
+    const iconPackConfig =
+      themeManager.getThemeConfiguration(docUri).mermaidIconPacks;
+    void this.pushThemeStateWithIconPacks(themeState, iconPackConfig, docUri);
+  }
+
+  // resolve icon pack files & send the final theme state to the webview
+  private async pushThemeStateWithIconPacks(
+    themeState: WebviewThemeState,
+    iconPackConfig: MermaidIconPackSetting[],
+    docUri: vscode.Uri
+  ): Promise<void> {
+    const mermaidIconPacks = await resolveMermaidIconPacks(
+      iconPackConfig,
+      docUri
+    );
+    const finalState: WebviewThemeState = { ...themeState, mermaidIconPacks };
+
+    if (!this.webviewHandle) {
+      return;
+    }
+    log.debug('pushThemeState - pushing theme state', finalState);
+    this.webviewHandle.setTheme(finalState);
   }
 
   pushRuntimeConfiguration(runtimeConfig: PreviewRuntimeConfig): void {

--- a/packages/extension-host/src/features/themes/IconPackResolver.ts
+++ b/packages/extension-host/src/features/themes/IconPackResolver.ts
@@ -1,51 +1,86 @@
 // packages/extension-host/src/features/themes/IconPackResolver.ts
-// read & cache mermaid icon pack JSON from local files for the webview
+// read, validate & cache mermaid icon pack JSON from local files for the webview
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { LRUCache } from '@mdx-preview/runtime-utils';
 import { createTaggedLogger } from '../../shared/logging/logger';
+import { isPathInsideAsync } from '../../shared/utils/path-utils';
 import {
   LogTags,
+  STANDARD_CACHE_TTL_MS,
+  type IconifyIconPack,
   type MermaidIconPackSetting,
   type ResolvedMermaidIconPack,
 } from '@mdx-preview/contracts';
+import { validateIconifyPack } from './iconPackValidation';
 
 const log = createTaggedLogger(LogTags.PREVIEW);
 
-// cache parsed JSON by absolute path & mtime so repeated theme pushes are cheap
-const cache = new Map<string, { mtimeMs: number; icons: unknown }>();
+// hard limits — packs come from workspace config & may be attacker-controlled
+const MAX_PACK_BYTES = 5 * 1024 * 1024;
+const MAX_PACK_ENTRIES = 64;
 
-// resolve a configured source path to an absolute path
-// absolute paths are used as-is, relative paths resolve against the workspace
-// folder (falling back to the document directory)
-function resolveSourcePath(source: string, docUri?: vscode.Uri): string {
-  if (path.isAbsolute(source)) {
-    return source;
+// reserved for the bundled builtin pack registered in the webview
+const RESERVED_PACK_NAMES = new Set(['logos']);
+// pack name is used as the icon prefix in diagrams (e.g. aws -> aws:Lambda)
+const PACK_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/i;
+
+// bounded cache of validated packs keyed by absolute path (mtime + size gated)
+interface CacheEntry {
+  mtimeMs: number;
+  size: number;
+  pack: IconifyIconPack;
+}
+const cache = new LRUCache<string, CacheEntry>({
+  maxEntries: MAX_PACK_ENTRIES,
+  ttlMs: STANDARD_CACHE_TTL_MS,
+});
+
+// base directory a relative source resolves against (workspace folder for the
+// doc, falling back to the document's own directory)
+function baseDirFor(docUri?: vscode.Uri): string | undefined {
+  if (!docUri) {
+    return undefined;
   }
-  if (docUri) {
-    const folder = vscode.workspace.getWorkspaceFolder(docUri);
-    const base = folder ? folder.uri.fsPath : path.dirname(docUri.fsPath);
-    return path.join(base, source);
-  }
-  return path.resolve(source);
+  const folder = vscode.workspace.getWorkspaceFolder(docUri);
+  return folder ? folder.uri.fsPath : path.dirname(docUri.fsPath);
 }
 
-// read & parse a single icon pack file (cached by mtime)
-async function readIconPack(absPath: string): Promise<unknown> {
+// read, validate & cache a single icon pack file (cached by mtime + size)
+// rejects non-regular files (FIFO/device) & oversized files before reading
+async function readIconPack(absPath: string): Promise<IconifyIconPack> {
   const stat = await fs.stat(absPath);
+  if (!stat.isFile()) {
+    throw new Error('not a regular file');
+  }
+  if (stat.size > MAX_PACK_BYTES) {
+    throw new Error(`file too large (${stat.size} bytes)`);
+  }
   const cached = cache.get(absPath);
-  if (cached && cached.mtimeMs === stat.mtimeMs) {
-    return cached.icons;
+  if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+    return cached.pack;
   }
   const raw = await fs.readFile(absPath, 'utf-8');
-  const icons = JSON.parse(raw);
-  cache.set(absPath, { mtimeMs: stat.mtimeMs, icons });
-  return icons;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // don't surface the parser error — its message can echo file bytes to logs
+    throw new Error('invalid JSON');
+  }
+  const pack = validateIconifyPack(parsed);
+  if (!pack) {
+    throw new Error('not a valid Iconify icon pack');
+  }
+  cache.set(absPath, { mtimeMs: stat.mtimeMs, size: stat.size, pack });
+  return pack;
 }
 
-// resolve configured icon packs to JSON payloads for the webview
-// invalid or unreadable packs are skipped w/ a warning (never throws)
+// resolve configured icon packs to validated JSON payloads for the webview
+// gated on workspace trust; relative paths are confined to the workspace
+// invalid/unreadable/untrusted packs are skipped w/ a warning (never throws)
 export async function resolveMermaidIconPacks(
   entries: MermaidIconPackSetting[],
   docUri?: vscode.Uri
@@ -54,18 +89,70 @@ export async function resolveMermaidIconPacks(
     return [];
   }
 
+  // ! never read workspace-controlled paths in an untrusted workspace
+  // mirrors the trust gating around script execution / plantUmlServer
+  if (!vscode.workspace.isTrusted) {
+    log.warn(
+      `Skipping ${entries.length} mermaid icon pack(s): workspace is not trusted`
+    );
+    return [];
+  }
+
+  const base = baseDirFor(docUri);
   const resolved: ResolvedMermaidIconPack[] = [];
-  for (const entry of entries) {
-    if (!entry || typeof entry.name !== 'string' || !entry.source) {
-      log.warn(`Skipping invalid mermaid icon pack entry: ${JSON.stringify(entry)}`);
+  const seen = new Set<string>();
+
+  for (const entry of entries.slice(0, MAX_PACK_ENTRIES)) {
+    if (
+      !entry ||
+      typeof entry.name !== 'string' ||
+      typeof entry.source !== 'string' ||
+      !entry.source
+    ) {
+      log.warn(
+        `Skipping invalid mermaid icon pack entry: ${JSON.stringify(entry)}`
+      );
       continue;
     }
+    if (RESERVED_PACK_NAMES.has(entry.name) || !PACK_NAME_RE.test(entry.name)) {
+      log.warn(
+        `Skipping mermaid icon pack with reserved/invalid name "${entry.name}"`
+      );
+      continue;
+    }
+    if (seen.has(entry.name)) {
+      log.warn(`Skipping duplicate mermaid icon pack name "${entry.name}"`);
+      continue;
+    }
+
     try {
-      const absPath = resolveSourcePath(entry.source, docUri);
+      let absPath: string;
+      if (path.isAbsolute(entry.source)) {
+        // absolute source allowed only because the workspace is trusted above
+        absPath = entry.source;
+      } else {
+        if (!base) {
+          log.warn(
+            `Skipping mermaid icon pack "${entry.name}": no workspace base for relative source`
+          );
+          continue;
+        }
+        absPath = path.resolve(base, entry.source);
+        // confine relative sources to the base dir (realpath defeats ../ & symlink escape)
+        if (!(await isPathInsideAsync(absPath, base))) {
+          log.warn(
+            `Skipping mermaid icon pack "${entry.name}": source escapes the workspace folder`
+          );
+          continue;
+        }
+      }
       const icons = await readIconPack(absPath);
       resolved.push({ name: entry.name, icons });
+      seen.add(entry.name);
     } catch (error: unknown) {
-      log.warn(`Failed to load mermaid icon pack "${entry.name}" from ${entry.source}: ${error}`);
+      log.warn(
+        `Failed to load mermaid icon pack "${entry.name}" from ${entry.source}: ${error}`
+      );
     }
   }
   return resolved;

--- a/packages/extension-host/src/features/themes/IconPackResolver.ts
+++ b/packages/extension-host/src/features/themes/IconPackResolver.ts
@@ -1,0 +1,72 @@
+// packages/extension-host/src/features/themes/IconPackResolver.ts
+// read & cache mermaid icon pack JSON from local files for the webview
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { createTaggedLogger } from '../../shared/logging/logger';
+import {
+  LogTags,
+  type MermaidIconPackSetting,
+  type ResolvedMermaidIconPack,
+} from '@mdx-preview/contracts';
+
+const log = createTaggedLogger(LogTags.PREVIEW);
+
+// cache parsed JSON by absolute path & mtime so repeated theme pushes are cheap
+const cache = new Map<string, { mtimeMs: number; icons: unknown }>();
+
+// resolve a configured source path to an absolute path
+// absolute paths are used as-is, relative paths resolve against the workspace
+// folder (falling back to the document directory)
+function resolveSourcePath(source: string, docUri?: vscode.Uri): string {
+  if (path.isAbsolute(source)) {
+    return source;
+  }
+  if (docUri) {
+    const folder = vscode.workspace.getWorkspaceFolder(docUri);
+    const base = folder ? folder.uri.fsPath : path.dirname(docUri.fsPath);
+    return path.join(base, source);
+  }
+  return path.resolve(source);
+}
+
+// read & parse a single icon pack file (cached by mtime)
+async function readIconPack(absPath: string): Promise<unknown> {
+  const stat = await fs.stat(absPath);
+  const cached = cache.get(absPath);
+  if (cached && cached.mtimeMs === stat.mtimeMs) {
+    return cached.icons;
+  }
+  const raw = await fs.readFile(absPath, 'utf-8');
+  const icons = JSON.parse(raw);
+  cache.set(absPath, { mtimeMs: stat.mtimeMs, icons });
+  return icons;
+}
+
+// resolve configured icon packs to JSON payloads for the webview
+// invalid or unreadable packs are skipped w/ a warning (never throws)
+export async function resolveMermaidIconPacks(
+  entries: MermaidIconPackSetting[],
+  docUri?: vscode.Uri
+): Promise<ResolvedMermaidIconPack[]> {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return [];
+  }
+
+  const resolved: ResolvedMermaidIconPack[] = [];
+  for (const entry of entries) {
+    if (!entry || typeof entry.name !== 'string' || !entry.source) {
+      log.warn(`Skipping invalid mermaid icon pack entry: ${JSON.stringify(entry)}`);
+      continue;
+    }
+    try {
+      const absPath = resolveSourcePath(entry.source, docUri);
+      const icons = await readIconPack(absPath);
+      resolved.push({ name: entry.name, icons });
+    } catch (error: unknown) {
+      log.warn(`Failed to load mermaid icon pack "${entry.name}" from ${entry.source}: ${error}`);
+    }
+  }
+  return resolved;
+}

--- a/packages/extension-host/src/features/themes/ThemeManager.ts
+++ b/packages/extension-host/src/features/themes/ThemeManager.ts
@@ -57,6 +57,7 @@ export class ThemeManager extends WithSubscribers<
       ) as MermaidTheme,
       autoTheme: configManager.get(SETTINGS.AUTO_THEME, docUri),
       plantUmlServer: configManager.get(SETTINGS.PLANTUML_SERVER, docUri),
+      mermaidIconPacks: configManager.get(SETTINGS.MERMAID_ICON_PACKS, docUri),
     };
   }
 
@@ -132,6 +133,8 @@ export class ThemeManager extends WithSubscribers<
       mermaidTheme: config.mermaidTheme,
       isLight: this.isLightTheme(),
       plantUmlServer: config.plantUmlServer,
+      // resolved (file contents read) by PreviewWebviewBridge before sending
+      mermaidIconPacks: [],
     };
   }
 

--- a/packages/extension-host/src/features/themes/iconPackValidation.ts
+++ b/packages/extension-host/src/features/themes/iconPackValidation.ts
@@ -1,0 +1,79 @@
+// packages/extension-host/src/features/themes/iconPackValidation.ts
+// validate & narrow untrusted icon pack JSON to a safe, minimal Iconify shape
+
+import type { IconifyIcon, IconifyIconPack } from '@mdx-preview/contracts';
+
+// hard limits — packs come from workspace config & may be attacker-controlled
+export const MAX_ICONS_PER_PACK = 10000;
+export const MAX_BODY_LENGTH = 64 * 1024;
+
+// ! best-effort host-side pre-filter; the webview's DOMPurify pass (allowlist)
+// is the authoritative sanitizer. drops the obvious beacon/script vectors so
+// they never reach the RPC payload, logs, or the webview. CSP blocks inline JS
+// but img-src allows https:, so an <image>, external href, or a CSS url() (in a
+// style attr or <style>) referencing an external/protocol-relative URL is a
+// phone-home beacon. internal #fragment refs are allowed
+const UNSAFE_BODY_RE =
+  /<\s*(?:script|image|foreignobject|iframe|style)\b|javascript:|\son\w+\s*=|(?:(?:xlink:)?href\s*=|url\s*\()\s*["']?\s*(?!#)(?:[a-z][\w+.-]*:|\/\/)/i;
+
+// reject oversized bodies & those carrying external-resource/script markup
+export function isSafeIconBody(body: string): boolean {
+  return body.length <= MAX_BODY_LENGTH && !UNSAFE_BODY_RE.test(body);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+// validate & narrow untrusted JSON to the minimal Iconify shape
+// drops unknown fields, oversized/dangerous bodies & prototype keys
+// returns null if the result has no usable icons (pure & silent by design —
+// a hostile pack with thousands of bad icons must not spam the log)
+export function validateIconifyPack(raw: unknown): IconifyIconPack | null {
+  if (!isPlainObject(raw) || !isPlainObject(raw.icons)) {
+    return null;
+  }
+  const names = Object.keys(raw.icons);
+  if (names.length === 0 || names.length > MAX_ICONS_PER_PACK) {
+    return null;
+  }
+
+  const icons: Record<string, IconifyIcon> = {};
+  for (const name of names) {
+    if (
+      name === '__proto__' ||
+      name === 'constructor' ||
+      name === 'prototype'
+    ) {
+      continue;
+    }
+    const entry = raw.icons[name];
+    if (!isPlainObject(entry) || typeof entry.body !== 'string') {
+      continue;
+    }
+    if (!isSafeIconBody(entry.body)) {
+      continue;
+    }
+    const icon: IconifyIcon = { body: entry.body };
+    for (const key of ['width', 'height', 'left', 'top', 'rotate'] as const) {
+      if (typeof entry[key] === 'number') {
+        icon[key] = entry[key] as number;
+      }
+    }
+    for (const key of ['hFlip', 'vFlip'] as const) {
+      if (typeof entry[key] === 'boolean') {
+        icon[key] = entry[key] as boolean;
+      }
+    }
+    icons[name] = icon;
+  }
+  if (Object.keys(icons).length === 0) {
+    return null;
+  }
+
+  const pack: IconifyIconPack = { icons };
+  if (typeof raw.prefix === 'string') pack.prefix = raw.prefix;
+  if (typeof raw.width === 'number') pack.width = raw.width;
+  if (typeof raw.height === 'number') pack.height = raw.height;
+  return pack;
+}

--- a/packages/extension-host/src/features/themes/iconPackValidation.ts
+++ b/packages/extension-host/src/features/themes/iconPackValidation.ts
@@ -7,12 +7,9 @@ import type { IconifyIcon, IconifyIconPack } from '@mdx-preview/contracts';
 export const MAX_ICONS_PER_PACK = 10000;
 export const MAX_BODY_LENGTH = 64 * 1024;
 
-// ! best-effort host-side pre-filter; the webview's DOMPurify pass (allowlist)
-// is the authoritative sanitizer. drops the obvious beacon/script vectors so
-// they never reach the RPC payload, logs, or the webview. CSP blocks inline JS
-// but img-src allows https:, so an <image>, external href, or a CSS url() (in a
-// style attr or <style>) referencing an external/protocol-relative URL is a
-// phone-home beacon. internal #fragment refs are allowed
+// ! host-side pre-filter; the webview DOMPurify pass is the real sanitizer
+// drop external href/url(), <image>, <script>, <style>, <foreignobject> & on*
+// handlers before they reach the RPC payload, logs or the webview
 const UNSAFE_BODY_RE =
   /<\s*(?:script|image|foreignobject|iframe|style)\b|javascript:|\son\w+\s*=|(?:(?:xlink:)?href\s*=|url\s*\()\s*["']?\s*(?!#)(?:[a-z][\w+.-]*:|\/\/)/i;
 
@@ -25,10 +22,9 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-// validate & narrow untrusted JSON to the minimal Iconify shape
-// drops unknown fields, oversized/dangerous bodies & prototype keys
-// returns null if the result has no usable icons (pure & silent by design —
-// a hostile pack with thousands of bad icons must not spam the log)
+// validate & narrow untrusted JSON to the minimal Iconify shape; drop unknown
+// fields, oversized/dangerous bodies & prototype keys. return null if no
+// usable icons remain — silent so a hostile pack can't spam the log
 export function validateIconifyPack(raw: unknown): IconifyIconPack | null {
   if (!isPlainObject(raw) || !isPlainObject(raw.icons)) {
     return null;
@@ -72,8 +68,14 @@ export function validateIconifyPack(raw: unknown): IconifyIconPack | null {
   }
 
   const pack: IconifyIconPack = { icons };
-  if (typeof raw.prefix === 'string') pack.prefix = raw.prefix;
-  if (typeof raw.width === 'number') pack.width = raw.width;
-  if (typeof raw.height === 'number') pack.height = raw.height;
+  if (typeof raw.prefix === 'string') {
+    pack.prefix = raw.prefix;
+  }
+  if (typeof raw.width === 'number') {
+    pack.width = raw.width;
+  }
+  if (typeof raw.height === 'number') {
+    pack.height = raw.height;
+  }
   return pack;
 }

--- a/packages/extension-host/src/features/themes/types.ts
+++ b/packages/extension-host/src/features/themes/types.ts
@@ -23,6 +23,7 @@ export {
 
 import type {
   CodeBlockTheme,
+  MermaidIconPackSetting,
   MermaidTheme,
   PreviewTheme,
 } from '@mdx-preview/contracts';
@@ -34,4 +35,5 @@ export interface ThemeConfiguration {
   mermaidTheme: MermaidTheme;
   autoTheme: boolean;
   plantUmlServer: string;
+  mermaidIconPacks: MermaidIconPackSetting[];
 }

--- a/packages/extension-host/src/shared/config/setting-keys.ts
+++ b/packages/extension-host/src/shared/config/setting-keys.ts
@@ -4,6 +4,7 @@
 import { SecurityPolicy } from '../../features/security/SecurityPolicy';
 import {
   type FrameworkSetting,
+  type MermaidIconPackSetting,
   type PreviewScrollSyncValue,
   type SourceLineHighlightColorValue,
   type TailwindEnabledValue,
@@ -36,6 +37,7 @@ export interface SettingTypes {
   'preview.scrollSync': PreviewScrollSyncValue;
   'preview.shimSideRail': boolean;
   'diagrams.plantUmlServer': string;
+  'diagrams.mermaidIconPacks': MermaidIconPackSetting[];
   'build.useSucraseTranspiler': boolean;
   'tailwind.enabled': TailwindEnabledValue;
   'tailwind.maxFileSizeBytes': number;
@@ -88,6 +90,7 @@ export const SETTINGS = {
   COMPONENTS_BUILTINS: 'components.builtins' as const,
   COMPONENTS_UNKNOWN_BEHAVIOR: 'components.unknownBehavior' as const,
   PLANTUML_SERVER: 'diagrams.plantUmlServer' as const,
+  MERMAID_ICON_PACKS: 'diagrams.mermaidIconPacks' as const,
   OPEN_MDX_LINKS_IN_PREVIEW: 'preview.openMdxLinksInPreview' as const,
   DEBUG_OUTPUT: 'advanced.debugOutput' as const,
   WATCHER_DEBOUNCE_MS: 'advanced.watcherDebounceMs' as const,
@@ -105,6 +108,7 @@ export const THEME_KEYS: readonly SettingKey[] = [
   SETTINGS.MERMAID_THEME,
   SETTINGS.AUTO_THEME,
   SETTINGS.PLANTUML_SERVER,
+  SETTINGS.MERMAID_ICON_PACKS,
 ] as const;
 
 export const PREVIEW_RUNTIME_CONFIG_KEYS: readonly SettingKey[] = [

--- a/packages/webview-client/package.json
+++ b/packages/webview-client/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "eslint src --fix"
   },
   "dependencies": {
+    "@iconify-json/logos": "^1.2.0",
     "@mdx-js/react": "^3.0.0",
     "@mdx-preview/contracts": "*",
     "@mdx-preview/runtime-utils": "*",

--- a/packages/webview-client/src/features/diagrams/ui/MermaidRenderer/MermaidRenderer.tsx
+++ b/packages/webview-client/src/features/diagrams/ui/MermaidRenderer/MermaidRenderer.tsx
@@ -4,8 +4,24 @@
 import { LogTags } from '@mdx-preview/contracts';
 import { createDiagramRenderer } from '../DiagramRenderer/createDiagramRenderer';
 import { useTheme } from '../../../theme/runtime';
+import { useEffect } from 'react';
 import { loadMermaid } from '../../utils/mermaidLoader';
+import {
+  registerBuiltinIconPacks,
+  registerDynamicIconPacks,
+  setPendingDynamicPacks,
+  getPendingDynamicPacks,
+} from '../../utils/mermaidIconPacks';
 import './MermaidRenderer.css';
+
+// read mermaid theme & keep configured icon packs in sync for the renderer
+function useMermaidThemeValue(): string {
+  const { mermaidTheme, mermaidIconPacks } = useTheme();
+  useEffect(() => {
+    setPendingDynamicPacks(mermaidIconPacks);
+  }, [mermaidIconPacks]);
+  return mermaidTheme;
+}
 
 // check if mermaid theme is dark (needs dark background)
 function isDarkMermaidTheme(theme: string): boolean {
@@ -27,13 +43,18 @@ export const MermaidRenderer = createDiagramRenderer<MermaidProps>({
   errorLabel: 'Mermaid parse error',
   loadingText: 'Loading diagram...',
   logTag: LogTags.MERMAID_RENDERER,
-  useThemeValue: () => useTheme().mermaidTheme,
+  useThemeValue: useMermaidThemeValue,
   toDataTheme: (theme) => (isDarkMermaidTheme(theme) ? 'dark' : 'light'),
   render: async (_props, signal, mermaidTheme) => {
     const { code, id } = _props;
     const isDark = isDarkMermaidTheme(mermaidTheme);
 
     const mermaid = await loadMermaid();
+
+    // register icon packs (idempotent) so architecture-beta diagrams can use
+    // icons like logos:aws-lambda or user-configured packs
+    registerBuiltinIconPacks(mermaid);
+    registerDynamicIconPacks(mermaid, getPendingDynamicPacks());
 
     // only re-initialize if theme or dark state changed (perf optimization)
     const needsReinit =

--- a/packages/webview-client/src/features/diagrams/utils/mermaidIconPacks.ts
+++ b/packages/webview-client/src/features/diagrams/utils/mermaidIconPacks.ts
@@ -1,9 +1,83 @@
 // packages/webview-client/src/features/diagrams/utils/mermaidIconPacks.ts
 // register icon packs for mermaid architecture diagrams
 
-import type { ResolvedMermaidIconPack } from '@mdx-preview/contracts';
+import DOMPurify from 'dompurify';
+import type { Config } from 'dompurify';
+import type {
+  IconifyIcon,
+  IconifyIconPack,
+  ResolvedMermaidIconPack,
+} from '@mdx-preview/contracts';
 import logosIcons from '@iconify-json/logos/icons.json';
 import type { MermaidModule } from './mermaidLoader';
+
+// re-sanitize icon bodies in the webview — never trust host RPC data blindly.
+// forbid external-resource elements/attrs so a malicious pack can't beacon out
+// under the webview CSP (img-src allows https:)
+const ICON_BODY_PURIFY_CONFIG: Config = {
+  USE_PROFILES: { svg: true, svgFilters: true },
+  FORBID_TAGS: [
+    'image',
+    'feImage',
+    'foreignObject',
+    'script',
+    'a',
+    'use',
+    'style',
+  ],
+  // style is dropped too: DOMPurify does not sanitize CSS, so a url() inside it
+  // would survive as an external-resource beacon under img-src https:
+  FORBID_ATTR: ['href', 'xlink:href', 'style'],
+};
+
+// sanitize one icon body. wrap in <svg> so DOMPurify parses the fragment in SVG
+// context (bare svg children parsed as HTML get mangled/dropped), then extract
+// the sanitized inner markup
+function sanitizeIconBody(body: string): string {
+  const wrapped = `<svg xmlns="http://www.w3.org/2000/svg">${body}</svg>`;
+  const clean = DOMPurify.sanitize(wrapped, ICON_BODY_PURIFY_CONFIG) as string;
+  const inner = /<svg\b[^>]*>([\s\S]*)<\/svg>/i.exec(clean);
+  return inner ? inner[1] : '';
+}
+
+// 'logos' is the builtin; user pack names must be a simple prefix token
+const DYNAMIC_PACK_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/i;
+
+// strip dangerous markup from each icon body before registering
+// treat the host payload as untrusted RPC data, not the declared type
+function sanitizeIconPack(
+  pack: ResolvedMermaidIconPack
+): IconifyIconPack | null {
+  const source = pack.icons as unknown;
+  if (!source || typeof source !== 'object') {
+    return null;
+  }
+  const iconMap = (source as { icons?: unknown }).icons;
+  if (!iconMap || typeof iconMap !== 'object') {
+    return null;
+  }
+  const icons: Record<string, IconifyIcon> = {};
+  for (const [key, value] of Object.entries(
+    iconMap as Record<string, unknown>
+  )) {
+    if (
+      !value ||
+      typeof value !== 'object' ||
+      typeof (value as { body?: unknown }).body !== 'string'
+    ) {
+      continue;
+    }
+    const icon = value as IconifyIcon;
+    icons[key] = {
+      ...icon,
+      body: sanitizeIconBody(icon.body),
+    };
+  }
+  if (Object.keys(icons).length === 0) {
+    return null;
+  }
+  return { ...(source as IconifyIconPack), icons };
+}
 
 // bundled "logos" pack includes AWS service logos (logos:aws-lambda etc)
 // loaded locally (not via CDN) so it works offline & under the webview CSP
@@ -49,10 +123,18 @@ export function registerDynamicIconPacks(
     if (!pack || !pack.name || registeredDynamicPacks.has(pack.name)) {
       continue;
     }
+    // reject the reserved builtin name & any non-prefix-token name
+    if (pack.name === 'logos' || !DYNAMIC_PACK_NAME_RE.test(pack.name)) {
+      continue;
+    }
+    const safe = sanitizeIconPack(pack);
+    if (!safe) {
+      continue;
+    }
     mermaid.default.registerIconPacks([
       {
         name: pack.name,
-        loader: () => pack.icons as never,
+        loader: () => safe as never,
       },
     ]);
     registeredDynamicPacks.add(pack.name);

--- a/packages/webview-client/src/features/diagrams/utils/mermaidIconPacks.ts
+++ b/packages/webview-client/src/features/diagrams/utils/mermaidIconPacks.ts
@@ -11,7 +11,7 @@ import type {
 import logosIcons from '@iconify-json/logos/icons.json';
 import type { MermaidModule } from './mermaidLoader';
 
-// re-sanitize icon bodies in the webview — never trust host RPC data blindly.
+// re-sanitize icon bodies in the webview — never trust host RPC data blindly
 // forbid external-resource elements/attrs so a malicious pack can't beacon out
 // under the webview CSP (img-src allows https:)
 const ICON_BODY_PURIFY_CONFIG: Config = {
@@ -25,8 +25,8 @@ const ICON_BODY_PURIFY_CONFIG: Config = {
     'use',
     'style',
   ],
-  // style is dropped too: DOMPurify does not sanitize CSS, so a url() inside it
-  // would survive as an external-resource beacon under img-src https:
+  // style is dropped too — DOMPurify doesn't sanitize CSS, so a url() in a style
+  // attr would survive as an external-resource beacon under img-src
   FORBID_ATTR: ['href', 'xlink:href', 'style'],
 };
 

--- a/packages/webview-client/src/features/diagrams/utils/mermaidIconPacks.ts
+++ b/packages/webview-client/src/features/diagrams/utils/mermaidIconPacks.ts
@@ -1,0 +1,67 @@
+// packages/webview-client/src/features/diagrams/utils/mermaidIconPacks.ts
+// register icon packs for mermaid architecture diagrams
+
+import type { ResolvedMermaidIconPack } from '@mdx-preview/contracts';
+import logosIcons from '@iconify-json/logos/icons.json';
+import type { MermaidModule } from './mermaidLoader';
+
+// bundled "logos" pack includes AWS service logos (logos:aws-lambda etc)
+// loaded locally (not via CDN) so it works offline & under the webview CSP
+let builtinRegistered = false;
+
+// names of dynamic packs already registered (avoid redundant re-registration)
+const registeredDynamicPacks = new Set<string>();
+
+// latest dynamic packs pushed from the host (read by the renderer at render time)
+let pendingDynamicPacks: ResolvedMermaidIconPack[] = [];
+
+// store the latest dynamic packs (called by the theme-value hook)
+export function setPendingDynamicPacks(packs: ResolvedMermaidIconPack[]): void {
+  pendingDynamicPacks = packs;
+}
+
+// get the latest dynamic packs
+export function getPendingDynamicPacks(): ResolvedMermaidIconPack[] {
+  return pendingDynamicPacks;
+}
+
+// register the bundled builtin icon pack on the given mermaid instance
+export function registerBuiltinIconPacks(mermaid: MermaidModule): void {
+  if (builtinRegistered) {
+    return;
+  }
+  mermaid.default.registerIconPacks([
+    {
+      name: 'logos',
+      loader: () => logosIcons,
+    },
+  ]);
+  builtinRegistered = true;
+}
+
+// register user-configured icon packs pushed from the extension host
+// each pack is registered once by name (mermaid stores packs by name)
+export function registerDynamicIconPacks(
+  mermaid: MermaidModule,
+  packs: ResolvedMermaidIconPack[]
+): void {
+  for (const pack of packs) {
+    if (!pack || !pack.name || registeredDynamicPacks.has(pack.name)) {
+      continue;
+    }
+    mermaid.default.registerIconPacks([
+      {
+        name: pack.name,
+        loader: () => pack.icons as never,
+      },
+    ]);
+    registeredDynamicPacks.add(pack.name);
+  }
+}
+
+// reset guards (used by tests & module-cache resets)
+export function resetMermaidIconPacks(): void {
+  builtinRegistered = false;
+  registeredDynamicPacks.clear();
+  pendingDynamicPacks = [];
+}

--- a/packages/webview-client/src/features/theme/runtime/context.tsx
+++ b/packages/webview-client/src/features/theme/runtime/context.tsx
@@ -8,6 +8,7 @@ import type {
   CodeBlockTheme,
   MermaidTheme,
   PreviewTheme,
+  ResolvedMermaidIconPack,
   WebviewThemeState,
 } from '@mdx-preview/contracts';
 import {
@@ -27,6 +28,7 @@ interface ThemeContextValue {
   codeBlockTheme: CodeBlockTheme;
   mermaidTheme: MermaidTheme;
   plantUmlServer: string;
+  mermaidIconPacks: ResolvedMermaidIconPack[];
   // handler for extension to push theme state
   setPreviewThemeState: (state: WebviewThemeState) => void;
 }
@@ -45,6 +47,9 @@ function useThemeValue(): ThemeContextValue {
   const [plantUmlServer, setPlantUmlServer] = useState<string>(
     DEFAULT_PLANTUML_SERVER
   );
+  const [mermaidIconPacks, setMermaidIconPacks] = useState<
+    ResolvedMermaidIconPack[]
+  >([]);
   const [isLight, setIsLight] = useState(true);
 
   // track VS Code theme changes (local detection for UI only)
@@ -69,6 +74,7 @@ function useThemeValue(): ThemeContextValue {
     setMermaidTheme(state.mermaidTheme);
     setIsLight(state.isLight);
     setPlantUmlServer(state.plantUmlServer);
+    setMermaidIconPacks(state.mermaidIconPacks);
   }, []);
 
   const value = useMemo<ThemeContextValue>(
@@ -80,6 +86,7 @@ function useThemeValue(): ThemeContextValue {
       codeBlockTheme,
       mermaidTheme,
       plantUmlServer,
+      mermaidIconPacks,
       setPreviewThemeState,
     }),
     [
@@ -88,6 +95,7 @@ function useThemeValue(): ThemeContextValue {
       codeBlockTheme,
       mermaidTheme,
       plantUmlServer,
+      mermaidIconPacks,
       setPreviewThemeState,
     ]
   );

--- a/scripts/check-test-philosophy.mjs
+++ b/scripts/check-test-philosophy.mjs
@@ -43,6 +43,8 @@ const EXACT_ALLOWED = new Set([
   'tests/extension/rpc-input-validation.test.ts',
   'tests/extension/security/checkFsPath.test.ts',
   'tests/extension/tailwind/TailwindProcessor.test.ts',
+  'tests/extension/themes/IconPackResolver.test.ts',
+  'tests/extension/themes/iconPackValidation.test.ts',
   'tests/extension/workspace-events.test.ts',
   'tests/webview/App.test.ts',
   'tests/webview/export-html.test.ts',
@@ -57,6 +59,7 @@ const EXACT_ALLOWED = new Set([
   'tests/webview/shimLoader.test.ts',
   'tests/webview/source-line-highlight.test.ts',
   'tests/webview/webview-rpc-client.test.ts',
+  'tests/webview/mermaidIconPacks.test.ts',
 ]);
 
 const CASE_COUNT_OVERRIDES = new Map([
@@ -72,6 +75,9 @@ const CASE_COUNT_OVERRIDES = new Map([
   ['tests/extension/workspace-events.test.ts', 5],
   ['tests/webview/SafePreview.test.ts', 6],
   ['tests/webview/source-line-highlight.test.ts', 7],
+  ['tests/extension/themes/iconPackValidation.test.ts', 6],
+  ['tests/extension/themes/IconPackResolver.test.ts', 8],
+  ['tests/webview/mermaidIconPacks.test.ts', 7],
 ]);
 
 function toRepoPath(rootDir, fullPath) {

--- a/tests/extension/preview/PreviewWebviewBridge.test.ts
+++ b/tests/extension/preview/PreviewWebviewBridge.test.ts
@@ -80,16 +80,19 @@ describe('PreviewWebviewBridge', () => {
     );
   });
 
-  it('pushes theme state after the webview handshake completes', () => {
+  it('pushes theme state after the webview handshake completes', async () => {
     const handle = createMockHandle();
     const watcherManager = createWatcherManager();
     bridge.setWebviewHandle(handle as never, watcherManager as never);
 
     bridge.onWebviewReady(mockDocUri as never);
+    // icon-pack resolution is async; let the deferred setTheme settle
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(handle.setTheme).toHaveBeenCalledWith({
       previewTheme: 'github-light',
       codeBlockTheme: 'auto',
+      mermaidIconPacks: [],
     });
   });
 

--- a/tests/extension/themes/IconPackResolver.test.ts
+++ b/tests/extension/themes/IconPackResolver.test.ts
@@ -1,0 +1,155 @@
+// tests/extension/themes/IconPackResolver.test.ts
+// verify icon pack resolution: trust gating, path containment & file limits
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const mockWorkspaceFolders = vi.fn();
+const mockIsTrusted = vi.fn();
+
+vi.mock('vscode', () => ({
+  workspace: {
+    get workspaceFolders() {
+      return mockWorkspaceFolders();
+    },
+    get isTrusted() {
+      return mockIsTrusted();
+    },
+    getWorkspaceFolder(uri: { fsPath: string }) {
+      const folders = (mockWorkspaceFolders() || []) as Array<{
+        uri: { fsPath: string };
+      }>;
+      return folders.find(
+        (folder) =>
+          uri.fsPath === folder.uri.fsPath ||
+          uri.fsPath.startsWith(folder.uri.fsPath + '/')
+      );
+    },
+  },
+}));
+
+import { resolveMermaidIconPacks } from '../../../packages/extension-host/src/features/themes/IconPackResolver';
+
+const SAMPLE = { icons: { box: { body: '<path d="M0 0h24v24H0z"/>' } } };
+
+let wsDir: string;
+let docUri: { fsPath: string };
+
+function writePack(rel: string, json: unknown): void {
+  const target = path.join(wsDir, rel);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, JSON.stringify(json));
+}
+
+// the resolver expects a vscode.Uri; a bare fsPath bag is enough at runtime
+function uri(fsPath: string): never {
+  return { fsPath } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  wsDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'iconpack-')));
+  docUri = { fsPath: path.join(wsDir, 'doc.mdx') };
+  mockIsTrusted.mockReturnValue(true);
+  mockWorkspaceFolders.mockReturnValue([{ uri: { fsPath: wsDir } }]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  try {
+    fs.rmSync(wsDir, { recursive: true, force: true });
+  } catch {
+    // best effort temp cleanup
+  }
+});
+
+describe('resolveMermaidIconPacks', () => {
+  it('resolves a valid in-workspace relative pack', async () => {
+    writePack('icons/pack.json', SAMPLE);
+    const out = await resolveMermaidIconPacks(
+      [{ name: 'aws', source: './icons/pack.json' }],
+      uri(docUri.fsPath)
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('aws');
+    expect(Object.keys(out[0].icons.icons)).toEqual(['box']);
+  });
+
+  it('reads nothing in an untrusted workspace', async () => {
+    writePack('icons/pack.json', SAMPLE);
+    mockIsTrusted.mockReturnValue(false);
+    const out = await resolveMermaidIconPacks(
+      [{ name: 'aws', source: './icons/pack.json' }],
+      uri(docUri.fsPath)
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('rejects relative sources that escape the workspace', async () => {
+    const out = await resolveMermaidIconPacks(
+      [{ name: 'aws', source: '../../../../etc/hostname' }],
+      uri(docUri.fsPath)
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('skips the reserved name "logos" and invalid names', async () => {
+    writePack('icons/pack.json', SAMPLE);
+    const out = await resolveMermaidIconPacks(
+      [
+        { name: 'logos', source: './icons/pack.json' },
+        { name: 'has space', source: './icons/pack.json' },
+        { name: 'evil:prefix', source: './icons/pack.json' },
+      ],
+      uri(docUri.fsPath)
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('skips non-regular files (e.g. a directory source)', async () => {
+    fs.mkdirSync(path.join(wsDir, 'icons'), { recursive: true });
+    const out = await resolveMermaidIconPacks(
+      [{ name: 'dir', source: './icons' }],
+      uri(docUri.fsPath)
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('rejects malformed / non-Iconify JSON', async () => {
+    writePack('bad.json', { not: 'a pack' });
+    const out = await resolveMermaidIconPacks(
+      [{ name: 'bad', source: './bad.json' }],
+      uri(docUri.fsPath)
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('drops a beacon icon but keeps the pack when other icons are safe', async () => {
+    writePack('mix.json', {
+      icons: {
+        good: { body: '<path d="M0 0"/>' },
+        bad: { body: '<image href="https://evil.example/x"/>' },
+      },
+    });
+    const out = await resolveMermaidIconPacks(
+      [{ name: 'mix', source: './mix.json' }],
+      uri(docUri.fsPath)
+    );
+    expect(out).toHaveLength(1);
+    expect(Object.keys(out[0].icons.icons)).toEqual(['good']);
+  });
+
+  it('deduplicates repeated pack names', async () => {
+    writePack('icons/pack.json', SAMPLE);
+    const out = await resolveMermaidIconPacks(
+      [
+        { name: 'aws', source: './icons/pack.json' },
+        { name: 'aws', source: './icons/pack.json' },
+      ],
+      uri(docUri.fsPath)
+    );
+    expect(out).toHaveLength(1);
+  });
+});

--- a/tests/extension/themes/iconPackValidation.test.ts
+++ b/tests/extension/themes/iconPackValidation.test.ts
@@ -1,0 +1,149 @@
+// tests/extension/themes/iconPackValidation.test.ts
+// verify untrusted icon pack JSON is validated, narrowed & body-sanitized
+
+import { describe, it, expect } from 'vitest';
+import {
+  validateIconifyPack,
+  isSafeIconBody,
+  MAX_BODY_LENGTH,
+  MAX_ICONS_PER_PACK,
+} from '../../../packages/extension-host/src/features/themes/iconPackValidation';
+
+describe('isSafeIconBody', () => {
+  it('accepts plain vector markup', () => {
+    expect(isSafeIconBody('<path fill="currentColor" d="M3 3h18v18H3z"/>')).toBe(
+      true
+    );
+    expect(isSafeIconBody('<g><circle cx="12" cy="12" r="10"/></g>')).toBe(true);
+  });
+  it('allows internal fragment refs', () => {
+    expect(isSafeIconBody('<rect fill="url(#g)"/><use href="#shape"/>')).toBe(
+      true
+    );
+  });
+  it('rejects <image> beacons', () => {
+    expect(isSafeIconBody('<image href="https://evil.example/x"/>')).toBe(false);
+  });
+  it('rejects external href on any element', () => {
+    expect(isSafeIconBody('<use xlink:href="https://evil.example/x"/>')).toBe(
+      false
+    );
+  });
+  it('rejects protocol-relative & data: hrefs', () => {
+    expect(isSafeIconBody('<use href="//evil.example/x"/>')).toBe(false);
+    expect(isSafeIconBody('<use href="data:image/svg+xml,x"/>')).toBe(false);
+  });
+  it('rejects external CSS url() (style attr & <style>), allows safe/internal CSS', () => {
+    expect(
+      isSafeIconBody('<rect style="mask-image:url(https://evil.example/x)"/>')
+    ).toBe(false);
+    expect(isSafeIconBody('<rect style="filter:url(//evil.example)"/>')).toBe(
+      false
+    );
+    expect(isSafeIconBody('<style>@import url(https://evil.example)</style>')).toBe(
+      false
+    );
+    expect(isSafeIconBody('<rect style="fill:#fff;stroke:red"/>')).toBe(true);
+    expect(isSafeIconBody('<rect fill="url(#grad)"/>')).toBe(true);
+  });
+  it('rejects <script>, <foreignObject> & <iframe>', () => {
+    expect(isSafeIconBody('<script>alert(1)</script>')).toBe(false);
+    expect(isSafeIconBody('<foreignObject><b/></foreignObject>')).toBe(false);
+    expect(isSafeIconBody('<iframe src="https://evil.example"/>')).toBe(false);
+  });
+  it('rejects inline event handlers & javascript: urls', () => {
+    expect(isSafeIconBody('<path onload="x()"/>')).toBe(false);
+    expect(isSafeIconBody('<a href="javascript:alert(1)">x</a>')).toBe(false);
+  });
+  it('rejects oversized bodies', () => {
+    expect(isSafeIconBody('a'.repeat(MAX_BODY_LENGTH + 1))).toBe(false);
+  });
+});
+
+describe('validateIconifyPack', () => {
+  it('returns null for non-objects, arrays & null', () => {
+    expect(validateIconifyPack(null)).toBeNull();
+    expect(validateIconifyPack('x')).toBeNull();
+    expect(validateIconifyPack([])).toBeNull();
+    expect(validateIconifyPack({})).toBeNull();
+  });
+  it('returns null when the icons map is missing or empty', () => {
+    expect(validateIconifyPack({ icons: {} })).toBeNull();
+    expect(validateIconifyPack({ icons: 'x' })).toBeNull();
+  });
+  it('normalizes a valid pack & strips unknown fields', () => {
+    const out = validateIconifyPack({
+      prefix: 'aws',
+      width: 24,
+      height: 24,
+      foo: 'bar',
+      icons: { box: { body: '<path d="M0 0"/>', evil: 'x', width: 16 } },
+    });
+    expect(out).toEqual({
+      prefix: 'aws',
+      width: 24,
+      height: 24,
+      icons: { box: { body: '<path d="M0 0"/>', width: 16 } },
+    });
+  });
+  it('drops icons with non-string or unsafe bodies, keeps safe ones', () => {
+    const out = validateIconifyPack({
+      icons: {
+        good: { body: '<path d="M0 0"/>' },
+        noBody: { width: 10 },
+        beacon: { body: '<image href="https://evil.example/x"/>' },
+      },
+    });
+    expect(Object.keys(out!.icons)).toEqual(['good']);
+  });
+  it('skips prototype-polluting keys without polluting Object.prototype', () => {
+    const out = validateIconifyPack(
+      JSON.parse(
+        '{"icons":{"__proto__":{"body":"<path/>"},"constructor":{"body":"<path/>"},"ok":{"body":"<path/>"}}}'
+      )
+    );
+    expect(Object.keys(out!.icons)).toEqual(['ok']);
+    expect(Object.prototype.hasOwnProperty.call(out!.icons, '__proto__')).toBe(
+      false
+    );
+    expect(({} as Record<string, unknown>).body).toBeUndefined();
+  });
+  it('returns null when every icon is dropped', () => {
+    expect(
+      validateIconifyPack({ icons: { a: { body: '<script>x</script>' } } })
+    ).toBeNull();
+  });
+  it('preserves geometry & flip transforms', () => {
+    const out = validateIconifyPack({
+      icons: {
+        i: {
+          body: '<path/>',
+          width: 1,
+          height: 2,
+          left: 3,
+          top: 4,
+          rotate: 1,
+          hFlip: true,
+          vFlip: false,
+        },
+      },
+    });
+    expect(out!.icons.i).toEqual({
+      body: '<path/>',
+      width: 1,
+      height: 2,
+      left: 3,
+      top: 4,
+      rotate: 1,
+      hFlip: true,
+      vFlip: false,
+    });
+  });
+  it('rejects packs exceeding the icon-count cap', () => {
+    const icons: Record<string, { body: string }> = {};
+    for (let i = 0; i <= MAX_ICONS_PER_PACK; i++) {
+      icons['i' + i] = { body: '<path/>' };
+    }
+    expect(validateIconifyPack({ icons })).toBeNull();
+  });
+});

--- a/tests/extension/themes/iconPackValidation.test.ts
+++ b/tests/extension/themes/iconPackValidation.test.ts
@@ -10,109 +10,84 @@ import {
 } from '../../../packages/extension-host/src/features/themes/iconPackValidation';
 
 describe('isSafeIconBody', () => {
-  it('accepts plain vector markup', () => {
-    expect(isSafeIconBody('<path fill="currentColor" d="M3 3h18v18H3z"/>')).toBe(
+  it('accepts plain vector markup & internal fragment refs', () => {
+    expect(
+      isSafeIconBody('<path fill="currentColor" d="M3 3h18v18H3z"/>')
+    ).toBe(true);
+    expect(isSafeIconBody('<g><circle cx="12" cy="12" r="10"/></g>')).toBe(
       true
     );
-    expect(isSafeIconBody('<g><circle cx="12" cy="12" r="10"/></g>')).toBe(true);
-  });
-  it('allows internal fragment refs', () => {
     expect(isSafeIconBody('<rect fill="url(#g)"/><use href="#shape"/>')).toBe(
       true
     );
+    expect(isSafeIconBody('<rect style="fill:#fff;stroke:red"/>')).toBe(true);
   });
-  it('rejects <image> beacons', () => {
-    expect(isSafeIconBody('<image href="https://evil.example/x"/>')).toBe(false);
-  });
-  it('rejects external href on any element', () => {
+
+  it('rejects external-resource, script & oversized bodies', () => {
+    expect(isSafeIconBody('<image href="https://evil.example/x"/>')).toBe(
+      false
+    );
     expect(isSafeIconBody('<use xlink:href="https://evil.example/x"/>')).toBe(
       false
     );
-  });
-  it('rejects protocol-relative & data: hrefs', () => {
     expect(isSafeIconBody('<use href="//evil.example/x"/>')).toBe(false);
     expect(isSafeIconBody('<use href="data:image/svg+xml,x"/>')).toBe(false);
-  });
-  it('rejects external CSS url() (style attr & <style>), allows safe/internal CSS', () => {
     expect(
       isSafeIconBody('<rect style="mask-image:url(https://evil.example/x)"/>')
     ).toBe(false);
     expect(isSafeIconBody('<rect style="filter:url(//evil.example)"/>')).toBe(
       false
     );
-    expect(isSafeIconBody('<style>@import url(https://evil.example)</style>')).toBe(
-      false
-    );
-    expect(isSafeIconBody('<rect style="fill:#fff;stroke:red"/>')).toBe(true);
-    expect(isSafeIconBody('<rect fill="url(#grad)"/>')).toBe(true);
-  });
-  it('rejects <script>, <foreignObject> & <iframe>', () => {
+    expect(
+      isSafeIconBody('<style>@import url(https://evil.example)</style>')
+    ).toBe(false);
     expect(isSafeIconBody('<script>alert(1)</script>')).toBe(false);
     expect(isSafeIconBody('<foreignObject><b/></foreignObject>')).toBe(false);
     expect(isSafeIconBody('<iframe src="https://evil.example"/>')).toBe(false);
-  });
-  it('rejects inline event handlers & javascript: urls', () => {
     expect(isSafeIconBody('<path onload="x()"/>')).toBe(false);
     expect(isSafeIconBody('<a href="javascript:alert(1)">x</a>')).toBe(false);
-  });
-  it('rejects oversized bodies', () => {
     expect(isSafeIconBody('a'.repeat(MAX_BODY_LENGTH + 1))).toBe(false);
   });
 });
 
 describe('validateIconifyPack', () => {
-  it('returns null for non-objects, arrays & null', () => {
+  it('rejects non-pack inputs & packs that yield no usable icons', () => {
     expect(validateIconifyPack(null)).toBeNull();
     expect(validateIconifyPack('x')).toBeNull();
     expect(validateIconifyPack([])).toBeNull();
     expect(validateIconifyPack({})).toBeNull();
-  });
-  it('returns null when the icons map is missing or empty', () => {
     expect(validateIconifyPack({ icons: {} })).toBeNull();
     expect(validateIconifyPack({ icons: 'x' })).toBeNull();
+    expect(
+      validateIconifyPack({ icons: { a: { body: '<script>x</script>' } } })
+    ).toBeNull();
   });
-  it('normalizes a valid pack & strips unknown fields', () => {
-    const out = validateIconifyPack({
-      prefix: 'aws',
-      width: 24,
-      height: 24,
-      foo: 'bar',
-      icons: { box: { body: '<path d="M0 0"/>', evil: 'x', width: 16 } },
-    });
-    expect(out).toEqual({
+
+  it('narrows a valid pack: strips unknown fields & drops unsafe icons', () => {
+    expect(
+      validateIconifyPack({
+        prefix: 'aws',
+        width: 24,
+        height: 24,
+        foo: 'bar',
+        icons: { box: { body: '<path d="M0 0"/>', evil: 'x', width: 16 } },
+      })
+    ).toEqual({
       prefix: 'aws',
       width: 24,
       height: 24,
       icons: { box: { body: '<path d="M0 0"/>', width: 16 } },
     });
-  });
-  it('drops icons with non-string or unsafe bodies, keeps safe ones', () => {
-    const out = validateIconifyPack({
+    const mixed = validateIconifyPack({
       icons: {
         good: { body: '<path d="M0 0"/>' },
         noBody: { width: 10 },
         beacon: { body: '<image href="https://evil.example/x"/>' },
       },
     });
-    expect(Object.keys(out!.icons)).toEqual(['good']);
+    expect(Object.keys(mixed!.icons)).toEqual(['good']);
   });
-  it('skips prototype-polluting keys without polluting Object.prototype', () => {
-    const out = validateIconifyPack(
-      JSON.parse(
-        '{"icons":{"__proto__":{"body":"<path/>"},"constructor":{"body":"<path/>"},"ok":{"body":"<path/>"}}}'
-      )
-    );
-    expect(Object.keys(out!.icons)).toEqual(['ok']);
-    expect(Object.prototype.hasOwnProperty.call(out!.icons, '__proto__')).toBe(
-      false
-    );
-    expect(({} as Record<string, unknown>).body).toBeUndefined();
-  });
-  it('returns null when every icon is dropped', () => {
-    expect(
-      validateIconifyPack({ icons: { a: { body: '<script>x</script>' } } })
-    ).toBeNull();
-  });
+
   it('preserves geometry & flip transforms', () => {
     const out = validateIconifyPack({
       icons: {
@@ -139,11 +114,23 @@ describe('validateIconifyPack', () => {
       vFlip: false,
     });
   });
-  it('rejects packs exceeding the icon-count cap', () => {
-    const icons: Record<string, { body: string }> = {};
+
+  it('blocks prototype pollution & enforces the icon-count cap', () => {
+    const out = validateIconifyPack(
+      JSON.parse(
+        '{"icons":{"__proto__":{"body":"<path/>"},"constructor":{"body":"<path/>"},"ok":{"body":"<path/>"}}}'
+      )
+    );
+    expect(Object.keys(out!.icons)).toEqual(['ok']);
+    expect(Object.prototype.hasOwnProperty.call(out!.icons, '__proto__')).toBe(
+      false
+    );
+    expect(({} as Record<string, unknown>).body).toBeUndefined();
+
+    const many: Record<string, { body: string }> = {};
     for (let i = 0; i <= MAX_ICONS_PER_PACK; i++) {
-      icons['i' + i] = { body: '<path/>' };
+      many['i' + i] = { body: '<path/>' };
     }
-    expect(validateIconifyPack({ icons })).toBeNull();
+    expect(validateIconifyPack({ icons: many })).toBeNull();
   });
 });

--- a/tests/helpers/mock-services.ts
+++ b/tests/helpers/mock-services.ts
@@ -67,6 +67,7 @@ export const mockPreviewManager = {
 export const mockThemeManager = {
   getWebviewThemeState: vi.fn(() => ({})),
   extractThemeFromFrontmatter: vi.fn(() => ({})),
+  getThemeConfiguration: vi.fn(() => ({ mermaidIconPacks: [] })),
 };
 
 export const mockConfigCache = {

--- a/tests/webview/mermaidIconPacks.test.ts
+++ b/tests/webview/mermaidIconPacks.test.ts
@@ -70,9 +70,9 @@ describe('registerDynamicIconPacks', () => {
         '<rect style="mask-image:url(https://evil.example/x)"/><path d="M0 0"/>'
       ),
     ]);
-    const out = registered
-      .find((r) => r.name === 'aws')!
-      .loader() as { icons: Record<string, { body: string }> };
+    const out = registered.find((r) => r.name === 'aws')!.loader() as {
+      icons: Record<string, { body: string }>;
+    };
     expect(out.icons.sample.body).not.toContain('evil.example');
     expect(out.icons.sample.body).not.toContain('style');
     expect(out.icons.sample.body).toContain('path');
@@ -83,9 +83,9 @@ describe('registerDynamicIconPacks', () => {
     registerDynamicIconPacks(mermaid, [
       pack('icons', '<circle cx="12" cy="12" r="10"/><path d="M2 2"/>'),
     ]);
-    const out = registered
-      .find((r) => r.name === 'icons')!
-      .loader() as { icons: Record<string, { body: string }> };
+    const out = registered.find((r) => r.name === 'icons')!.loader() as {
+      icons: Record<string, { body: string }>;
+    };
     expect(out.icons.sample.body).toContain('circle');
     expect(out.icons.sample.body).toContain('path');
   });

--- a/tests/webview/mermaidIconPacks.test.ts
+++ b/tests/webview/mermaidIconPacks.test.ts
@@ -1,0 +1,114 @@
+// tests/webview/mermaidIconPacks.test.ts
+// verify dynamic icon packs are name-checked & DOMPurify-sanitized before register
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// decouple from the bundled pack so the test runs without the iconify dep
+vi.mock('@iconify-json/logos/icons.json', () => ({
+  default: { prefix: 'logos', icons: {} },
+}));
+
+import {
+  registerBuiltinIconPacks,
+  registerDynamicIconPacks,
+  resetMermaidIconPacks,
+} from '../../packages/webview-client/src/features/diagrams/utils/mermaidIconPacks';
+import type { MermaidModule } from '../../packages/webview-client/src/features/diagrams/utils/mermaidLoader';
+import type { ResolvedMermaidIconPack } from '../../packages/contracts/src/index';
+
+function makeMermaid() {
+  const registered: Array<{ name: string; loader: () => unknown }> = [];
+  const mermaid = {
+    default: {
+      registerIconPacks: (
+        packs: Array<{ name: string; loader: () => unknown }>
+      ) => {
+        registered.push(...packs);
+      },
+    },
+  } as unknown as MermaidModule;
+  return { mermaid, registered };
+}
+
+function pack(name: string, body: string): ResolvedMermaidIconPack {
+  return { name, icons: { icons: { sample: { body } } } };
+}
+
+beforeEach(() => {
+  resetMermaidIconPacks();
+});
+
+describe('registerBuiltinIconPacks', () => {
+  it('registers the builtin logos pack exactly once', () => {
+    const { mermaid, registered } = makeMermaid();
+    registerBuiltinIconPacks(mermaid);
+    registerBuiltinIconPacks(mermaid);
+    expect(registered.filter((r) => r.name === 'logos')).toHaveLength(1);
+  });
+});
+
+describe('registerDynamicIconPacks', () => {
+  it('sanitizes icon bodies, stripping <image> & external refs', () => {
+    const { mermaid, registered } = makeMermaid();
+    registerDynamicIconPacks(mermaid, [
+      pack('aws', '<image href="https://evil.example/x"/><path d="M0 0"/>'),
+    ]);
+    const reg = registered.find((r) => r.name === 'aws');
+    expect(reg).toBeDefined();
+    const out = reg!.loader() as { icons: Record<string, { body: string }> };
+    expect(out.icons.sample.body).not.toContain('<image');
+    expect(out.icons.sample.body).not.toContain('evil.example');
+    expect(out.icons.sample.body).toContain('path');
+  });
+
+  it('strips style attributes (CSS url() beacon vector)', () => {
+    const { mermaid, registered } = makeMermaid();
+    registerDynamicIconPacks(mermaid, [
+      pack(
+        'aws',
+        '<rect style="mask-image:url(https://evil.example/x)"/><path d="M0 0"/>'
+      ),
+    ]);
+    const out = registered
+      .find((r) => r.name === 'aws')!
+      .loader() as { icons: Record<string, { body: string }> };
+    expect(out.icons.sample.body).not.toContain('evil.example');
+    expect(out.icons.sample.body).not.toContain('style');
+    expect(out.icons.sample.body).toContain('path');
+  });
+
+  it('preserves safe vector markup through sanitization', () => {
+    const { mermaid, registered } = makeMermaid();
+    registerDynamicIconPacks(mermaid, [
+      pack('icons', '<circle cx="12" cy="12" r="10"/><path d="M2 2"/>'),
+    ]);
+    const out = registered
+      .find((r) => r.name === 'icons')!
+      .loader() as { icons: Record<string, { body: string }> };
+    expect(out.icons.sample.body).toContain('circle');
+    expect(out.icons.sample.body).toContain('path');
+  });
+
+  it('skips the reserved name "logos"', () => {
+    const { mermaid, registered } = makeMermaid();
+    registerDynamicIconPacks(mermaid, [pack('logos', '<path/>')]);
+    expect(registered.find((r) => r.name === 'logos')).toBeUndefined();
+  });
+
+  it('skips invalid pack names', () => {
+    const { mermaid, registered } = makeMermaid();
+    registerDynamicIconPacks(mermaid, [
+      pack('has space', '<path/>'),
+      pack('evil:prefix', '<path/>'),
+    ]);
+    expect(registered).toHaveLength(0);
+  });
+
+  it('registers each pack name only once', () => {
+    const { mermaid, registered } = makeMermaid();
+    registerDynamicIconPacks(mermaid, [pack('aws', '<path/>')]);
+    registerDynamicIconPacks(mermaid, [pack('aws', '<path/>')]);
+    expect(registered.filter((r) => r.name === 'aws')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION

Hey! Love this extension 

One thing I wanted was **icons in Mermaid `architecture-beta` diagrams** (the AWS/GCP/Azure service-logo diagrams you see in Mermaid Chart). Mermaid 11 supports this via `registerIconPacks`, but the extension wasn't registering any packs, and "fetch the pack from a CDN" doesn't work inside the webview because of the CSP. So I wired it up properly.

### What's in here

**1. A built-in `logos` pack.** The Iconify `logos` set is bundled, so AWS service logos work with zero config:

```
architecture-beta
    service fn(logos:aws-lambda)[Lambda]
    service db(logos:aws-dynamodb)[DynamoDB]
    fn:R --> L:db
```

**2. A setting to add your own packs** — `mdx-preview.diagrams.mermaidIconPacks`:

```jsonc
"mdx-preview.diagrams.mermaidIconPacks": [
  { "name": "aws", "source": "./icons/aws-full.json" }
]
```

Drop any Iconify JSON in your workspace, point a `{ name, source }` entry at it, reload the preview — no rebuild. There's an `examples/aws-architecture/` folder demonstrating both the built-in pack and a custom one.

### How it works 

The key constraint is the webview CSP: `connect-src` only allows the webview origin, so the webview can't `fetch` a CDN pack — same reason PlantUML/Kroki rendering happens host-side. So:

- the **extension host** reads the pack JSON files (async, cached by mtime) in a new `IconPackResolver`,
- sends the parsed packs to the webview over the **existing theme RPC** (`WebviewThemeState`), resolved at the single `PreviewWebviewBridge.pushThemeState` choke point so `ThemeManager` stays sync,
- the webview registers them with `mermaid.registerIconPacks` alongside the built-in `logos` pack.

Everything is offline. Invalid/unreadable packs are skipped with a warning rather than throwing.

### Notes / things I'd love feedback on

- **Local files only** for now — I left URL sources out deliberately so the host isn't fetching arbitrary URLs; happy to add them behind the trust state if you'd want that.
- Packs currently ride along in `WebviewThemeState` (re-sent on each theme push). Fine in practice, but a dedicated one-shot RPC would be a cleaner optimization — let me know your preference.
- Default is `[]`, so zero behavior change for anyone not using it. The built-in `logos` pack adds some bundle size only because it's imported; can scope it down to a curated subset if that's a concern.

Verified: full typecheck, webview lint, all `check:guardrails`, prod build, and a packaged `.vsix` tested locally. Let me know if you'd like anything restructured!

- **`package-lock.json` is included** (the `@iconify-json/logos` dep) — keep it in the PR.
---