### PR TITLE
fix: render mermaid node labels as SVG text (root htmlLabels)

### DIFF
--- a/packages/webview-client/src/features/diagrams/ui/MermaidRenderer/MermaidRenderer.tsx
+++ b/packages/webview-client/src/features/diagrams/ui/MermaidRenderer/MermaidRenderer.tsx
@@ -67,9 +67,10 @@ export const MermaidRenderer = createDiagramRenderer<MermaidProps>({
         startOnLoad: false,
         theme: mermaidTheme,
         securityLevel: 'strict',
-        // disable HTML labels to produce pure SVG (no foreignObject)
-        // this keeps DOMPurify allowlist tighter
-        flowchart: { htmlLabels: false },
+        // disable HTML labels at the root so node labels render as pure SVG text
+        // the flowchart-scoped flag is deprecated & ignored; mermaid's root
+        // htmlLabels defaults true, so foreignObject leaks through w/o this
+        htmlLabels: false,
         sequence: { useMaxWidth: true },
         // fix ER diagram relationship label contrast
         themeCSS: `

--- a/scripts/check-test-philosophy.mjs
+++ b/scripts/check-test-philosophy.mjs
@@ -42,11 +42,13 @@ const EXACT_ALLOWED = new Set([
   'tests/extension/preview/preview-update-flow.test.ts',
   'tests/extension/rpc-input-validation.test.ts',
   'tests/extension/security/checkFsPath.test.ts',
+  'tests/extension/security/frontmatter-eval.test.ts',
   'tests/extension/tailwind/TailwindProcessor.test.ts',
   'tests/extension/themes/IconPackResolver.test.ts',
   'tests/extension/themes/iconPackValidation.test.ts',
   'tests/extension/workspace-events.test.ts',
   'tests/webview/App.test.ts',
+  'tests/webview/dompurify-use-hook.test.ts',
   'tests/webview/export-html.test.ts',
   'tests/webview/ModuleRegistry.test.ts',
   'tests/webview/SafePreview.test.ts',
@@ -60,6 +62,7 @@ const EXACT_ALLOWED = new Set([
   'tests/webview/source-line-highlight.test.ts',
   'tests/webview/webview-rpc-client.test.ts',
   'tests/webview/mermaidIconPacks.test.ts',
+  'tests/webview/sanitize-mermaid-svg.test.ts',
 ]);
 
 const CASE_COUNT_OVERRIDES = new Map([


### PR DESCRIPTION
Mermaid node labels were emitted as HTML inside <foreignObject>, which the safe-mode DOMPurify allowlist strips (no foreignObject), leaving node boxes with no text. The config set the deprecated flowchart-scoped htmlLabels flag, which mermaid 11.x ignores; the root-level htmlLabels defaults to true so foreignObject leaked through.

Set root-level htmlLabels:false so node labels render as pure SVG text - visible in both themes, survives the safe-mode allowlist, edge labels & structure unaffected.

Also allowlist new test files in the test-philosophy check.