### PR TITLE
docs: refresh user-facing docs against current code

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A modern, actively maintained successor to the original [MDX Preview](https://ma
 - **Tailwind CSS** - Built-in Tailwind v4 compilation with auto-detection
 - **Syntax Highlighting** - Shiki-powered code blocks with 100+ languages and 24 themes
 - **Preview Themes** - 16 themes (GitHub, Atom, Solarized, etc.) with auto light/dark switching
-- **Mermaid Diagrams** - Flowcharts, sequence diagrams, state diagrams, and more
+- **Mermaid Diagrams** - Flowcharts, sequence, state, and `architecture-beta` diagrams, with configurable [Iconify](https://iconify.design) icon packs (built-in `logos` pack)
 - **PlantUML Diagrams** - Server-side rendering via configurable PlantUML server
 - **Graphviz Diagrams** - Client-side DOT graph rendering via WASM engine
 - **Math Expressions** - KaTeX for inline (`$...$`) and block (`$$...$$`) math
@@ -151,12 +151,13 @@ See [Security](./docs/security.md) for the full security model.
 | `mdx-preview.preview.sourceLineHighlight`      | `true`               | Highlight rendered blocks by source line on hover           |
 | `mdx-preview.preview.sourceLineHighlightColor` | `"dependent"`        | Highlight color mode: `dependent`, `white`, `black`, `auto` |
 | `mdx-preview.preview.scrollSync`               | `"off"`              | Scroll sync: `off`, `editorToPreview`, `previewToEditor`, `bidirectional` |
-| `mdx-preview.preview.shimSideRail`             | `true`               | Show the framework shim side rail when relevant             |
+| `mdx-preview.preview.shimSideRail`             | `true`               | Show side accent rails on callout/admonition shims          |
 | `mdx-preview.preview.openMdxLinksInPreview`    | `true`               | Open `.mdx` links in preview                                |
 | `mdx-preview.framework.componentShims`         | `true`               | Enable framework component shims                            |
 | `mdx-preview.components.builtins`              | `true`               | Enable built-in component shims                             |
 | `mdx-preview.components.unknownBehavior`       | `"placeholder"`      | Unknown component handling: `strip`, `placeholder`, `raw`   |
 | `mdx-preview.diagrams.plantUmlServer`          | `"https://kroki.io"` | PlantUML server URL                                         |
+| `mdx-preview.diagrams.mermaidIconPacks`        | `[]`                 | Iconify icon packs for Mermaid `architecture-beta` diagrams |
 | `mdx-preview.build.useSucraseTranspiler`       | `false`              | Use Sucrase instead of Babel                                |
 
 This table covers the most common settings. See [Configuration](./docs/configuration.md) for the full reference, including Tailwind tuning (`mdx-preview.tailwind.*`) and advanced options (`mdx-preview.advanced.*`).
@@ -187,7 +188,7 @@ See [Troubleshooting](./docs/troubleshooting.md) for more.
 - [Troubleshooting](./docs/troubleshooting.md) - Common issues and solutions
 - [Contributing](./docs/contributing.md) - Development setup and guidelines
 - [Architecture](./docs/architecture.mdx) - Extension and webview architecture
-- [Examples](./examples) - Working examples for Docusaurus, Starlight, Nextra, Next.js, PlantUML, Graphviz, lightbox/zoom, and more
+- [Examples](./examples) - Working examples for Docusaurus, Starlight, Nextra, Next.js, PlantUML, Graphviz, AWS architecture diagrams, lightbox/zoom, and more
 
 ## Credits
 

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -502,7 +502,7 @@ The mode is part of the runtime configuration pushed to the webview (`PreviewCon
 2. The handler resolves the active preview, picks the leading visible range (folded code can produce multiple), and computes the anchored source line at the 35% band.
 3. `queueScroll(preview, line)` writes the line into a per-`Preview` scheduler. Two dispatches are scheduled:
    - **Live dispatch** throttled at ~33 ms while the user is actively scrolling.
-   - **Settle dispatch** after `EDITOR_TO_PREVIEW_SCROLL_SETTLE_MS` (80 ms) of quiet for the final landing line.
+   - **Settle dispatch** after `SOURCE_LINE_SCROLL_SYNC_SETTLE_MS` (80 ms) of quiet for the final landing line.
 4. On dispatch, `preview.scrollToLine(line)` calls `WebviewRPC.scrollToLine`. The dispatch also sets `ignorePreviewUntilMs = now + 120 ms` so the resulting preview scroll does not bounce back as a `reportPreviewSourceLine`.
 
 **Preview → editor pipeline** (`packages/webview-client/src/features/preview/shared/hooks/usePreviewScrollSync.ts`):
@@ -854,9 +854,9 @@ graph TB
 
 **StyleCache:**
 
-- Dual-map architecture (referenced vs unreferenced)
-- Reference counting for proper cleanup
-- O(1) LRU eviction via Map insertion order
+- Shared LRUCache with reference-counted eviction protection
+- `isProtected` predicate keeps styles with active references (`refCount > 0`)
+- Unreferenced styles evicted in LRU order to stay under capacity
 
 **DependencyTracker:**
 
@@ -1040,10 +1040,11 @@ flowchart LR
 
 For Nextra projects, the extension resolves `_meta.json` files:
 
-```typescript title="packages/extension-host/src/features/framework/nextra/MetaResolver.ts"
+```typescript title="packages/contracts/src/preview/types.ts"
 interface NextraPageMeta {
   title?: string;
   layout?: 'default' | 'full' | 'raw';
+  description?: string;
   toc?: boolean;
 }
 ```
@@ -1114,13 +1115,11 @@ graph TD
 
 ```typescript
 buildCacheKey(
-  tailwindVersion, // 'v3' or 'v4'
-  extractedClasses, // 'flex gap-4 text-sm ...'
-  configPath, // '/path/to/tailwind.config.js'
-  configFileStamp, // mtime or error marker
-  entryCssPath, // '/path/to/globals.css'
-  entryFileStamp // mtime or error marker
-); // returns SHA1 hash
+  version, // 'v3' or 'v4'
+  content, // 'flex gap-4 text-sm ...'
+  configPath, // '/path/to/tailwind.config.js' | null
+  entryCssPath // '/path/to/globals.css' | null
+); // derives config/entry file stamps internally; returns SHA1 hash
 ```
 
 > [!NOTE]
@@ -1629,13 +1628,28 @@ DoS prevention via size and dependency limits:
 
 All HTML in Safe Mode is sanitized:
 
-```typescript title="packages/webview-client/src/features/preview/safe/SafePreview.tsx"
+```typescript title="packages/webview-client/src/features/preview/safe/security/allowlist.ts"
 import DOMPurify from 'dompurify';
 
-const sanitized = DOMPurify.sanitize(html, {
-  ADD_ATTR: ['target'],
-  ADD_TAGS: ['mermaid'],
-});
+// DOMPURIFY_CONFIG is a strict explicit allowlist (no ADD_TAGS); foreignObject
+// is excluded. Consumed once, via the useSafeModeProcessing hook.
+const DOMPURIFY_CONFIG = {
+  // HTML + KaTeX/MathML + SVG (foreignObject excluded; 'use' allowed)
+  ALLOWED_TAGS: ['h1', 'p', 'a', 'pre', 'code', 'table', 'svg', 'use' /* ... */],
+  // standard attrs + diagram data attributes
+  ALLOWED_ATTR: [
+    'href', 'src', 'class', 'xlink:href',
+    'data-mermaid-chart', 'data-mermaid-id',
+    'data-plantuml-code', 'data-graphviz-code',
+    'data-admonition-type', 'data-source-line' /* ... */,
+  ],
+  ADD_ATTR: ['target', 'rel'],
+  ALLOW_UNKNOWN_PROTOCOLS: false,
+  ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto|tel):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i,
+};
+
+// invoked in useSafeModeProcessing.ts
+const sanitized = DOMPurify.sanitize(html, DOMPURIFY_CONFIG);
 ```
 
 ### Security Checklist

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -16,17 +16,19 @@ describes all caches, their invalidation triggers, and troubleshooting guidance.
 | MDX Preview Config | ConfigCache.ts                         | PathCache             | -   | 100  | .mdx-previewrc.json watcher        |
 | Babel Options      | babel.ts                               | Singleton             | -   | 1    | Never (extension lifetime)         |
 | Sass Module        | SassHandler.ts                         | Map                   | -   | -    | PackageJsonWatcher, manual command |
-| Tailwind CSS       | TailwindProcessor.ts                   | ContentHashCache      | 5m  | 50   | Auto-expires, manual command       |
+| Tailwind CSS       | TailwindProcessor.ts                   | LRUCache              | 5m  | 50   | Auto-expires, manual command       |
 | Tailwind Scan      | TailwindProcessor.ts (scanCache field) | ContentHashCache      | 5m  | 200  | DependencyWatcher, auto-expires    |
 | Framework          | FrameworkDetector.ts                   | PathCache             | -   | -    | PackageJsonWatcher                 |
 | Root Directory     | checkFsPath.ts                         | Map                   | -   | -    | Workspace folder changes           |
+
+> The Tailwind CSS cache TTL (5m) and max entries (50) are the defaults of `mdx-preview.tailwind.cacheTtlSeconds` and `mdx-preview.tailwind.cacheMaxEntries` and can be overridden in settings; related Tailwind limits are `mdx-preview.tailwind.compilationTimeout` (15s) and `mdx-preview.tailwind.maxFileSizeBytes` (10MB).
 
 ### Webview-Side Caches (Browser)
 
 | Cache              | Location             | Type               | Max        | Invalidation Trigger            |
 | ------------------ | -------------------- | ------------------ | ---------- | ------------------------------- |
 | Module Cache       | ModuleCache.ts       | LRU (count+memory) | 500 / 50MB | Preview refresh, manual command |
-| Style Cache        | StyleCache.ts        | Dual-map LRU       | 100        | Preview refresh, manual command |
+| Style Cache        | StyleCache.ts        | Ref-counted LRU    | 100        | Preview refresh, manual command |
 | Dependency Tracker | DependencyTracker.ts | Multi-map          | -          | Preview refresh, manual command |
 
 ## Invalidation Triggers

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,7 @@ All settings are prefixed with `mdx-preview.` in `settings.json`.
 | `preview.sourceLineHighlight`      | boolean | `true`        | Highlight rendered blocks by source line on hover                         |
 | `preview.sourceLineHighlightColor` | string  | `"dependent"` | Highlight color mode: `"dependent"`, `"white"`, `"black"`, `"auto"`       |
 | `preview.scrollSync`               | string  | `"off"`       | Scroll sync: `"off"`, `"editorToPreview"`, `"previewToEditor"`, `"bidirectional"` |
-| `preview.shimSideRail`             | boolean | `true`        | Show the framework shim side rail when applicable                         |
+| `preview.shimSideRail`             | boolean | `true`        | Show left side-accent rails on callout and admonition shim blocks         |
 
 ### Theme Settings
 
@@ -54,6 +54,9 @@ All settings are prefixed with `mdx-preview.` in `settings.json`.
 | `preview.mermaidTheme`    | string  | `"default"`          | Mermaid diagram theme                                  |
 | `preview.autoTheme`       | boolean | `true`               | Auto-switch preview theme pairs based on VS Code theme |
 | `diagrams.plantUmlServer` | string  | `"https://kroki.io"` | PlantUML/Kroki server URL                              |
+| `diagrams.mermaidIconPacks` | array | `[]`                 | Iconify icon packs for Mermaid `architecture-beta` diagrams |
+
+Icon packs require a trusted workspace. Each entry is `{ "name": "...", "source": "..." }`, where `source` is a path to a local [Iconify](https://iconify.design) JSON file (relative paths resolve against the workspace folder). Reference icons in `architecture-beta` diagrams as `name:icon` (e.g. `logos:aws-lambda` from the built-in `logos` pack). See the [AWS architecture example](../examples/aws-architecture).
 
 ### Build Settings
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -152,7 +152,7 @@ See [`../tests/README.md`](../tests/README.md) for the current test philosophy a
 - TypeScript in strict mode
 - Prettier: single quotes, semicolons, 2-space indent, 80-column width
 - ESLint: custom rules plus project guardrails
-- Comments must follow [`../../dev-docs/comment-style.md`](../../dev-docs/comment-style.md)
+- Comments must follow the project comment style, enforced by `npm run check:comments` (see [`../scripts/check-comment-style.mjs`](../scripts/check-comment-style.mjs))
 
 Important guardrails:
 

--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -52,7 +52,7 @@ import TabItem from '@theme/TabItem';
 ````
 
 > [!NOTE]
-> Docusaurus admonitions are rendered using the built-in callout styles. Import paths like `@theme/Admonition` resolve to the generic Callout shim.
+> Docusaurus admonitions are rendered using the built-in callout styles. The bare `Admonition` element is aliased to the generic Callout shim.
 
 ---
 
@@ -218,7 +218,7 @@ Generic components can be used without imports when `components.builtins` is ena
 </Tabs>
 ```
 
-**Callout Types:**
+**Common Callout Types:**
 
 | Type      | Description            |
 | --------- | ---------------------- |
@@ -228,6 +228,8 @@ Generic components can be used without imports when `components.builtins` is ena
 | `warning` | Warning/caution        |
 | `danger`  | Error/danger           |
 | `success` | Success message        |
+
+The Callout shim accepts 17 types (plus aliases such as `caution` and `important`) and falls back to `note` for unknown values.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,6 +1,6 @@
 # Security Model
 
-> Last security review: 2026-04-24
+> Last security review: 2026-06-03
 
 MDX Preview implements a defense-in-depth security model with two rendering modes to balance functionality with protection. This document covers the trust model, Content Security Policy, Safe Mode, Trusted Mode, and security best practices.
 
@@ -180,11 +180,12 @@ All HTML output is sanitized before rendering:
 
 ```typescript
 import DOMPurify from 'dompurify';
+import { DOMPURIFY_CONFIG } from './security/allowlist';
 
-const sanitized = DOMPurify.sanitize(html, {
-  ADD_ATTR: ['target', 'data-mermaid'],
-  ADD_TAGS: ['mermaid'],
-});
+// DOMPURIFY_CONFIG is a strict explicit allowlist (ALLOWED_TAGS + ALLOWED_ATTR)
+// covering HTML, KaTeX math, and SVG for Mermaid (no foreignObject), with
+// ADD_ATTR: ['target', 'rel'] and protocol filtering via ALLOWED_URI_REGEXP.
+const sanitized = DOMPurify.sanitize(html, DOMPURIFY_CONFIG);
 ```
 
 **3. Strict Content Security Policy**
@@ -322,7 +323,7 @@ export function getCSP(
 }
 ```
 
-The optional `connectSrc` extension list (deduplicated against `webview.cspSource`) is what lets opt-in subsystems such as the PlantUML/Kroki client whitelist their server origin without weakening the rest of the policy.
+The `connectSrc` parameter is a reserved extension point that no current caller supplies, so `connect-src` is always just `webview.cspSource`. PlantUML/Kroki diagrams are rendered by the extension host proxy (`renderPlantUml`, a server-side fetch) to avoid CORS, so the sandboxed webview never connects to the diagram server itself.
 
 ### CSP Directives Explained
 
@@ -365,14 +366,22 @@ CSP can be disabled via `mdx-preview.preview.security: "disabled"`:
 Safe Mode uses DOMPurify with a carefully tuned configuration:
 
 ```typescript
-DOMPurify.sanitize(html, {
-  // Allow target attribute for links
-  ADD_ATTR: ['target', 'data-mermaid', 'data-code-block'],
-  // Allow mermaid custom element
-  ADD_TAGS: ['mermaid'],
-  // Allow data URIs for images
-  ALLOW_DATA_ATTR: true,
-});
+// packages/webview-client/src/features/preview/safe/security/allowlist.ts
+export const DOMPURIFY_CONFIG = {
+  // explicit element allowlist: headings, text, lists, code, links,
+  // tables, KaTeX math, and SVG (no foreignObject)
+  ALLOWED_TAGS: ['h1', 'p', 'a', 'pre', 'code', 'table', 'svg', 'use' /* ... */],
+  // explicit attribute allowlist, incl. diagram data attributes
+  ALLOWED_ATTR: [
+    'href', 'src', 'class', 'xlink:href',
+    'data-mermaid-chart', 'data-mermaid-id',
+    'data-plantuml-code', 'data-graphviz-code',
+    'data-admonition-type', 'data-source-line' /* ... */,
+  ],
+  ADD_ATTR: ['target', 'rel'],
+  ALLOW_UNKNOWN_PROTOCOLS: false,
+  ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto|tel):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i,
+};
 ```
 
 ### What Gets Sanitized
@@ -382,17 +391,17 @@ DOMPurify.sanitize(html, {
 | `<script>` tags | Removed |
 | `onclick` handlers | Removed |
 | `javascript:` URLs | Removed |
-| `data:` URLs (except images) | Removed |
+| `data:` URLs (all) | Removed (blocked by `ALLOWED_URI_REGEXP`) |
 | Unknown attributes | Removed |
-| SVG `<use>` elements | Sanitized |
+| SVG `<use>` elements | Allowed (in `ALLOWED_TAGS`; `xlink:href` permitted) |
+| `<foreignObject>` (e.g. Mermaid HTML labels) | Removed (not in allowlist) |
 
 ### Post-Processing
 
 After sanitization, additional processing occurs:
 
-1. **Link rewriting** - Add `target="_blank"` and `rel="noopener"`
-2. **Image path resolution** - Resolve relative paths to webview URIs
-3. **Code block enhancement** - Add copy buttons and language badges
+1. **Relative URL resolution** - Relative image/link URLs resolve against the base `href` (the document's webview URI) set in the host HTML
+2. **Code block enhancement** - Add copy buttons and language badges
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -626,9 +626,9 @@ You can also check the Output panel (View > Output > "MDX Preview") for configur
 
 | Tag               | Meaning                    |
 | ----------------- | -------------------------- |
-| `[TRUST_MANAGER]` | Trust state changes        |
+| `[TRUST-MANAGER]` | Trust state changes        |
 | `[PREVIEW]`       | Preview lifecycle events   |
-| `[MODULE]`        | Module resolution/fetching |
+| `[MODULE-SYSTEM]` | Module resolution/fetching |
 | `[CONFIG]`        | Configuration loading      |
 | `[FRAMEWORK]`     | Framework detection        |
 | `[TAILWIND]`      | Tailwind CSS processing    |
@@ -719,7 +719,7 @@ The sync target lands at the top-third reading band (~35% from the top of the vi
 
 1. You clicked a native interactive element (link, button, form control, `<details>`, `[role="button"]`, contenteditable). Source-line navigation intentionally defers to native behavior on those elements.
 2. The block has no `data-source-line` annotation. This happens for custom components in Trusted Mode that don't preserve the annotation.
-3. The preview is in an error state. Check the Output panel for a `[RPC_WEBVIEW]` warning like `Failed to open source line`.
+3. The preview is in an error state. Check the Output panel for a `[RPC-WEBVIEW]` warning like `Failed to open source line`.
 
 ### "Editor and preview keep fighting each other in bidirectional mode"
 

--- a/packages/extension-host/src/features/commands/data/authoring-guide.md
+++ b/packages/extension-host/src/features/commands/data/authoring-guide.md
@@ -116,7 +116,7 @@ Aliases also work: `:::abstract`, `:::tldr`, `:::error`, `:::faq`, `:::check`, e
 ````mdx
 ```javascript
 function greet(name) {
-  return \`Hello, \${name}!\`;
+  return `Hello, ${name}!`;
 }
 ```
 ````
@@ -399,9 +399,9 @@ import Details from '@theme/Details';
 </Tabs>
 
 <CodeBlock language="jsx" title="Component.jsx" showLineNumbers>
-  {\`function App() {
+  {`function App() {
   return <div>Hello</div>;
-}\`}
+}`}
 </CodeBlock>
 
 <Details summary="Click to expand">
@@ -871,5 +871,6 @@ const data = await response.json();
 | Tailwind CSS | `className="flex ..."` (Trusted Mode) |
 | MDX transclusion | `import X from './X.mdx'; <X />` (Trusted Mode) |
 | Custom layout | `export default Layout` (Trusted Mode) |
+| Export to HTML | `MDX: Export Preview as HTML` (toolbar or palette) |
 | Config file | `.mdx-previewrc.json` |
 ````


### PR DESCRIPTION
Audit-driven sync of user-facing docs to shipped 1.5.0 behavior:

- README: document mermaid architecture-beta icon packs (feature, settings table, examples); fix shimSideRail wording
- configuration: add diagrams.mermaidIconPacks setting + usage note; fix shimSideRail description
- security: replace stale DOMPurify config blocks with the real explicit allowlist; fix connect-src/PlantUML-CORS claim, sanitization table, and post-processing list; bump review date
- architecture: fix DOMPurify block + source titles, scroll-sync constant name, NextraPageMeta fence, StyleCache (ref-counted LRU), buildCacheKey
- frameworks: fix @theme/Admonition claim; clarify callout types
- troubleshooting: correct log tags to emitted hyphenated form
- caching: fix cache type labels; note Tailwind cache configurability
- contributing: repoint broken comment-style link to npm run check:comments
- authoring guide: re-sync bundled clipboard copy to canonical root (restore Export to HTML row, drop backslash-escaping)