### PR TITLE
deps: 2026-07-26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@tailwindcss/postcss": "^4.3.2",
         "ajv": "^8.20.0",
         "comlink": "^4.4.1",
-        "enhanced-resolve": "^5.24.1",
+        "enhanced-resolve": "^5.24.3",
         "es-module-lexer": "^2.3.0",
         "get-tsconfig": "^4.14.0",
         "hast-util-from-html-isomorphic": "^2.0.0",
@@ -5752,16 +5752,16 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -6214,15 +6214,15 @@
       }
     },
     "node_modules/concurrently": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
-      "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.4.tgz",
+      "integrity": "sha512-trZql+7l/0+WRAsAnEdctr4+iiOS6ZrViI6H8QWcCF9MFS/LT0dKpe8vluB1to6it+OxSI4VospFTIFMW8DJRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.4",
+        "shell-quote": "1.9.0",
         "supports-color": "10.2.2",
         "tree-kill": "1.2.2",
         "yargs": "18.0.0"
@@ -7084,6 +7084,20 @@
         "node": ">=22.12.0"
       }
     },
+    "node_modules/dependency-cruiser/node_modules/enhanced-resolve": {
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -7273,9 +7287,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
-      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
+      "version": "5.24.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -13424,9 +13438,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -849,7 +849,7 @@
     "@tailwindcss/postcss": "^4.3.2",
     "ajv": "^8.20.0",
     "comlink": "^4.4.1",
-    "enhanced-resolve": "^5.24.1",
+    "enhanced-resolve": "^5.24.3",
     "es-module-lexer": "^2.3.0",
     "get-tsconfig": "^4.14.0",
     "hast-util-from-html-isomorphic": "^2.0.0",


### PR DESCRIPTION
## Summary

Consolidates the open Dependabot set into the repository's dated dependency-maintenance format, and clears the three high-severity advisories that are currently failing the `Security audit` step of CI on `main`.

## Changes

**Security advisories** — `npm audit` goes from 3 high to 0. All three are transitive dev-tree fixes; no direct dependency range changed.
- `shell-quote` 1.8.4 → 1.9.0 — quadratic-complexity DoS in `parse()` ([GHSA-395f-4hp3-45gv](https://github.com/advisories/GHSA-395f-4hp3-45gv))
- `brace-expansion` 5.0.7 → 5.0.8 — unbounded expansion causing OOM ([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg))
- `concurrently` 10.0.3 → 10.0.4 — carrier of the vulnerable `shell-quote`

**Dependencies**
- `enhanced-resolve` 5.24.1 → 5.24.3 (from #117), kept in `dependencies` — it backs the module resolver at runtime

**CI**
- `actions/setup-node` v6 → v7 across `ci.yml` and `release.yml` (#116)

## Deferred, with reasons

| Update | PR | Why deferred |
| --- | --- | --- |
| `typescript` 6.0.3 → 7.0.2 | #118 | `typescript-eslint` 8.65.0 (current latest) still declares `typescript >=4.8.4 <6.1.0`. Same rationale as mdx-forge #136; revisit when typescript-eslint widens its peer range. |
| `katex` 0.17.0 → 0.18.1 | #117 | `rehype-katex` 7.0.1 depends on `katex ^0.16.0`. 0.18 namespaces its CSS classes, which would not match the markup the plugin emits — math rendering would lose styling. |
| `@types/vscode` 1.90.0 → 1.125.0 | #117 | Pinned exactly, in lockstep with `engines.vscode: ^1.90.0`. Raising the typings alone would let code compile against APIs absent from the declared minimum host. Bumping both is a product decision, not dependency maintenance. |

Because #117 is a grouped PR whose three members split across accept/defer, its two deferred members were not cherry-picked here; #117 and #118 should stay open.

## Verification

Run locally on this branch after a clean `npm ci`:
- `npm audit --audit-level=high` — 0 vulnerabilities (was 3 high)
- `npm run typecheck` — clean (root + contracts, runtime-utils, codegen)
- `npm run test:all` — 66 files, 301 tests passed
- `enhanced-resolve` resolves to 5.24.3 and remains in `dependencies`, not `devDependencies`

## Impact

No runtime source changes. This unblocks CI, which currently fails on `main` and on every open PR because the advisories were published after the last green run.

https://claude.ai/code/session_016xwRrBb3hJMgbG6faZFQw9
