### PR TITLE
fix: complete JSX development runtime preload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "hast-util-from-html-isomorphic": "^2.0.0",
         "is-module": "^1.0.0",
         "lodash.debounce": "^4.0.8",
-        "mdx-forge": "^0.9.0",
+        "mdx-forge": "^0.9.1",
         "postcss": "^8.5.23",
         "rehype-autolink-headings": "^7.1.0",
         "rehype-katex": "^7.0.1",
@@ -10907,9 +10907,9 @@
       "license": "MIT"
     },
     "node_modules/mdx-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/mdx-forge/-/mdx-forge-0.9.0.tgz",
-      "integrity": "sha512-XJjRmqzcynDSSAkIpBRH1NyvmXvO0uKF1v9rYVAwKg1nIxvoHT4Eg/yXsBqpYnru+2c24gGN98zsYj0byHTs6A==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/mdx-forge/-/mdx-forge-0.9.1.tgz",
+      "integrity": "sha512-PIjryT1VHyE8SBbCFmkAqdPQI7VV3DXq472XKpyYFyOltsy91uHHoyR+rDbFFfAATdJ067grQGYvps+VgajJZw==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -15787,7 +15787,7 @@
       "dependencies": {
         "@mdx-preview/contracts": "*",
         "@mdx-preview/runtime-utils": "*",
-        "mdx-forge": "^0.9.0"
+        "mdx-forge": "^0.9.1"
       }
     },
     "packages/contracts": {
@@ -15801,7 +15801,7 @@
       "dependencies": {
         "@mdx-preview/contracts": "*",
         "@mdx-preview/runtime-utils": "*",
-        "mdx-forge": "^0.9.0"
+        "mdx-forge": "^0.9.1"
       }
     },
     "packages/runtime-utils": {
@@ -15824,7 +15824,7 @@
         "comlink": "^4.4.1",
         "dompurify": "^3.4.11",
         "katex": "^0.18.1",
-        "mdx-forge": "^0.9.0",
+        "mdx-forge": "^0.9.1",
         "mermaid": "^11.16.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",

--- a/package.json
+++ b/package.json
@@ -856,7 +856,7 @@
     "hast-util-from-html-isomorphic": "^2.0.0",
     "is-module": "^1.0.0",
     "lodash.debounce": "^4.0.8",
-    "mdx-forge": "^0.9.0",
+    "mdx-forge": "^0.9.1",
     "postcss": "^8.5.23",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-katex": "^7.0.1",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -7,6 +7,6 @@
   "dependencies": {
     "@mdx-preview/contracts": "*",
     "@mdx-preview/runtime-utils": "*",
-    "mdx-forge": "^0.9.0"
+    "mdx-forge": "^0.9.1"
   }
 }

--- a/packages/extension-host/package.json
+++ b/packages/extension-host/package.json
@@ -10,6 +10,6 @@
   "dependencies": {
     "@mdx-preview/contracts": "*",
     "@mdx-preview/runtime-utils": "*",
-    "mdx-forge": "^0.9.0"
+    "mdx-forge": "^0.9.1"
   }
 }

--- a/packages/webview-client/package.json
+++ b/packages/webview-client/package.json
@@ -20,7 +20,7 @@
     "comlink": "^4.4.1",
     "dompurify": "^3.4.11",
     "katex": "^0.18.1",
-    "mdx-forge": "^0.9.0",
+    "mdx-forge": "^0.9.1",
     "mermaid": "^11.16.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/packages/webview-client/src/features/module-runtime/preload/core.ts
+++ b/packages/webview-client/src/features/module-runtime/preload/core.ts
@@ -14,10 +14,7 @@ import {
 import type { ModuleRegistry } from 'mdx-forge/browser/registry';
 
 export type PreloadedModuleId =
-  | (typeof PRELOADED_MODULE_IDS)[keyof typeof PRELOADED_MODULE_IDS]
-  | typeof JSX_DEV_RUNTIME_MODULE_ID;
-
-const JSX_DEV_RUNTIME_MODULE_ID = 'npm://react/jsx-dev-runtime@18';
+  (typeof PRELOADED_MODULE_IDS)[keyof typeof PRELOADED_MODULE_IDS];
 
 // production React leaves jsxDEV undefined, so reuse its production element factory
 const jsxDevRuntime = {
@@ -144,7 +141,7 @@ export function preloadCoreModules(
   });
 
   preloadEntry(registry, {
-    id: JSX_DEV_RUNTIME_MODULE_ID,
+    id: PRELOADED_MODULE_IDS.jsxDevRuntime,
     exports: jsxDevRuntime,
     aliases: ['react/jsx-dev-runtime', 'npm://react/jsx-dev-runtime'],
   });

--- a/tests/webview/preload-atomic-registration.test.ts
+++ b/tests/webview/preload-atomic-registration.test.ts
@@ -7,6 +7,7 @@ import {
   registry,
   setPreloadEntries,
 } from 'mdx-forge/browser';
+import { preloadCoreModules } from '../../packages/webview-client/src/features/module-runtime/preload/core';
 import {
   loadDocusaurusShims,
   preloadGenericShims,
@@ -93,6 +94,35 @@ describe('preload atomic registration', () => {
     expect(preloadGeneric).toHaveBeenCalledWith(registry);
     expect(byBareAlias).toBe(byShimPath);
     expect(typeof byBareAlias.default).toBe('function');
+
+    preloadCoreModules(registry, {});
+    const jsxDevRuntime = requireFromEntry('react/jsx-dev-runtime') as Record<
+      string,
+      unknown
+    >;
+    const jsxDEV = jsxDevRuntime.jsxDEV as (...args: unknown[]) => {
+      type: unknown;
+      props: Record<string, unknown>;
+    };
+
+    expect(registry.has(PRELOADED_MODULE_IDS.jsxDevRuntime)).toBe(true);
+    expect(typeof jsxDEV).toBe('function');
+
+    const element = jsxDEV(
+      'div',
+      { children: 'preview' },
+      undefined,
+      false,
+      {
+        fileName: '/workspace/docs/index.mdx',
+        lineNumber: 1,
+        columnNumber: 1,
+      },
+      undefined
+    );
+
+    expect(element.type).toBe('div');
+    expect(element.props.children).toBe('preview');
   });
 
   it('restores core, generic, & unchanged framework shims after cache clear', async () => {


### PR DESCRIPTION
## What changed

- consume `PRELOADED_MODULE_IDS.jsxDevRuntime` from `mdx-forge@^0.9.1` instead of duplicating its canonical module ID
- preload `react/jsx-dev-runtime` with a production-compatible `jsxDEV` implementation backed by React's `jsx` factory
- cover real core preload registration and synchronous resolution with a focused element-creation regression
- align all workspace manifests and the lockfile on the published registry package

## Why

React's production `react/jsx-dev-runtime` export leaves `jsxDEV` undefined, while precompiled dependencies can retain imports of that entry point. The webview therefore needs an explicit production-compatible preload, and mdx-forge should remain the owner of the canonical module identity.

## Impact

Trusted previews can evaluate dependencies compiled against `react/jsx-dev-runtime` without a missing-module failure or an undefined `jsxDEV` call. Safe Mode is unchanged.

## Checks

- `npm ci`
- `npx vitest run tests/webview/preload-atomic-registration.test.ts` (4 passed)
- `npm run format:check`
- `npm run typecheck`
- `npm run lint` (all guardrails passed)
- `npm test` (72 files, 274 tests passed)
- `npm run build`
- `npm run verify:codegen`
- `npm audit --omit=dev` (0 vulnerabilities)
- registry-backed `npm ls mdx-forge --all` (0.9.1 deduped across all workspaces)