### PR TITLE
chore: raise VS Code support floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
           - "minor"
           - "patch"
     ignore:
+      - dependency-name: "@types/vscode"
       - dependency-name: "eslint"
         update-types:
           - "version-update:semver-major"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **VS Code support floor**: the minimum supported VS Code version is now 1.104, and the extension API types match that compatibility baseline
+
 ## [1.7.5] - 2026-07-26
 
 Includes [#118](https://github.com/ggfincke/vsc-mdx-preview/pull/118),

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "@types/babel__core": "^7.20.5",
         "@types/lodash.debounce": "^4.0.9",
         "@types/node": "^26.1.0",
-        "@types/vscode": "1.90.0",
+        "@types/vscode": "1.104.0",
         "@typescript/native": "npm:typescript@^7.0.2",
         "@vscode/test-electron": "^3.1.0",
         "@vscode/vsce": "^3.9.2",
@@ -71,7 +71,7 @@
       },
       "engines": {
         "node": ">=18.0.0",
-        "vscode": "^1.90.0"
+        "vscode": "^1.104.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4734,9 +4734,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.90.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.90.0.tgz",
-      "integrity": "sha512-oT+ZJL7qHS9Z8bs0+WKf/kQ27qWYR3trsXpq46YDjFqBsMLG4ygGGjPaJ2tyrH0wJzjOEmDyg9PDJBBhWg9pkQ==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.104.0.tgz",
+      "integrity": "sha512-0KwoU2rZ2ecsTGFxo4K1+f+AErRsYW0fsp6A0zufzGuhyczc2IoKqYqcwXidKXmy2u8YB2GsYsOtiI9Izx3Tig==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "packages/*"
   ],
   "engines": {
-    "vscode": "^1.90.0",
+    "vscode": "^1.104.0",
     "node": ">=18.0.0"
   },
   "categories": [
@@ -823,7 +823,7 @@
     "@types/babel__core": "^7.20.5",
     "@types/lodash.debounce": "^4.0.9",
     "@types/node": "^26.1.0",
-    "@types/vscode": "1.90.0",
+    "@types/vscode": "1.104.0",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vscode/test-electron": "^3.1.0",
     "@vscode/vsce": "^3.9.2",

--- a/packages/extension-host/src/features/diagnostics/diagnostic-adapter.ts
+++ b/packages/extension-host/src/features/diagnostics/diagnostic-adapter.ts
@@ -86,7 +86,7 @@ export function toVsDiagnostic(d: Diagnostic): vscode.Diagnostic {
   // clickable code recovers the readability lost from the opaque MDXF id
   diagnostic.code = { value: d.code, target: docsUriForCode(d.code) };
 
-  // Diagnostic.data is runtime-supported but absent from @types/vscode 1.90; cast
+  // Diagnostic.data is runtime-supported but absent from @types/vscode 1.104; cast
   if (d.data !== undefined) {
     (diagnostic as vscode.Diagnostic & { data?: unknown }).data = d.data;
   }


### PR DESCRIPTION
## Summary

- raise the minimum supported VS Code version from `^1.90.0` to `^1.104.0`
- align `@types/vscode` with that minimum API contract
- ignore automated `@types/vscode` bumps so the support floor moves intentionally rather than on Dependabot's monthly cadence
- document the compatibility change under `Unreleased` and update the one source comment tied to the old type baseline

This is a compatibility-policy change only; runtime behavior is unchanged. Once a release containing this lands, VS Code versions older than 1.104 will remain on their latest compatible extension release.

## Verification

- `npm audit --audit-level=high` (0 vulnerabilities via clean install)
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm test` (72 files, 274 tests)
- `npm run build`
- `npm run check:import-meta-shim`
- `npm run size:report`
- `npm run vscode:package -- --no-yarn` (6.5 MB VSIX)
